### PR TITLE
Drop `patch()` for celery in tests, now that we use in-mem backend

### DIFF
--- a/bookwyrm/tests/activitypub/test_base_activity.py
+++ b/bookwyrm/tests/activitypub/test_base_activity.py
@@ -22,25 +22,15 @@ from bookwyrm.activitypub import ActivitySerializerError
 from bookwyrm import models
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.suggested_users.rerank_user_task.delay")
-@patch("bookwyrm.suggested_users.remove_user_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class BaseActivity(TestCase):
     """the super class for model-linked activitypub dataclasses"""
 
     @classmethod
     def setUpTestData(cls):
         """we're probably going to re-use this so why copy/paste"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
+        cls.user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
+        )
         cls.user.remote_id = "http://example.com/a/b"
         cls.user.save(broadcast=False, update_fields=["remote_id"])
 
@@ -68,29 +58,29 @@ class BaseActivity(TestCase):
         with open(image_path, "rb") as image_file:
             self.image_data = image_file.read()
 
-    def test_get_representative_not_existing(self, *_):
+    def test_get_representative_not_existing(self):
         """test that an instance representative actor is created if it does not exist"""
         representative = get_representative()
         self.assertIsInstance(representative, models.User)
 
-    def test_init(self, *_):
+    def test_init(self):
         """simple successfully init"""
         instance = ActivityObject(id="a", type="b")
         self.assertTrue(hasattr(instance, "id"))
         self.assertTrue(hasattr(instance, "type"))
 
-    def test_init_missing(self, *_):
+    def test_init_missing(self):
         """init with missing required params"""
         with self.assertRaises(ActivitySerializerError):
             ActivityObject()
 
-    def test_init_extra_fields(self, *_):
+    def test_init_extra_fields(self):
         """init ignoring additional fields"""
         instance = ActivityObject(id="a", type="b", fish="c")
         self.assertTrue(hasattr(instance, "id"))
         self.assertTrue(hasattr(instance, "type"))
 
-    def test_init_default_field(self, *_):
+    def test_init_default_field(self):
         """replace an existing required field with a default field"""
 
         @dataclass(init=False)
@@ -103,7 +93,7 @@ class BaseActivity(TestCase):
         self.assertEqual(instance.id, "a")
         self.assertEqual(instance.type, "TestObject")
 
-    def test_serialize(self, *_):
+    def test_serialize(self):
         """simple function for converting dataclass to dict"""
         instance = ActivityObject(id="a", type="b")
         serialized = instance.serialize()
@@ -112,7 +102,7 @@ class BaseActivity(TestCase):
         self.assertEqual(serialized["type"], "b")
 
     @responses.activate
-    def test_resolve_remote_id(self, *_):
+    def test_resolve_remote_id(self):
         """look up or load remote data"""
         # existing item
         result = resolve_remote_id("http://example.com/a/b", model=models.User)
@@ -126,10 +116,7 @@ class BaseActivity(TestCase):
             status=200,
         )
 
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            result = resolve_remote_id(
-                "https://example.com/user/mouse", model=models.User
-            )
+        result = resolve_remote_id("https://example.com/user/mouse", model=models.User)
         self.assertIsInstance(result, models.User)
         self.assertEqual(result.remote_id, "https://example.com/user/mouse")
         self.assertEqual(result.name, "MOUSE?? MOUSE!!")
@@ -155,10 +142,7 @@ class BaseActivity(TestCase):
             status=200,
         )
 
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            result = resolve_remote_id(
-                "https://example.com/user/moose", model=models.User
-            )
+        result = resolve_remote_id("https://example.com/user/moose", model=models.User)
 
         self.assertTrue(
             models.User.objects.filter(
@@ -176,14 +160,14 @@ class BaseActivity(TestCase):
         self.assertEqual(alias.name, "Ali As")
         self.assertEqual(result.also_known_as.first(), alias)  # Ali is alias of Moose
 
-    def test_to_model_invalid_model(self, *_):
+    def test_to_model_invalid_model(self):
         """catch mismatch between activity type and model type"""
         instance = ActivityObject(id="a", type="b")
         with self.assertRaises(ActivitySerializerError):
             instance.to_model(model=models.User)
 
     @responses.activate
-    def test_to_model_image(self, *_):
+    def test_to_model_image(self):
         """update an image field"""
         activity = activitypub.Person(
             id=self.user.remote_id,
@@ -209,20 +193,17 @@ class BaseActivity(TestCase):
         with self.assertRaises(ValueError):
             self.user.avatar.file
 
-        # this would trigger a broadcast because it's a local user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            activity.to_model(model=models.User, instance=self.user)
+        activity.to_model(model=models.User, instance=self.user)
         self.assertIsNotNone(self.user.avatar.file)
         self.assertEqual(self.user.name, "New Name")
         self.assertEqual(self.user.key_pair.public_key, "hi")
 
-    def test_to_model_many_to_many(self, *_):
+    def test_to_model_many_to_many(self):
         """annoying that these all need special handling"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Status.objects.create(
-                content="test status",
-                user=self.user,
-            )
+        status = models.Status.objects.create(
+            content="test status",
+            user=self.user,
+        )
         book = models.Edition.objects.create(
             title="Test Edition", remote_id="http://book.com/book"
         )
@@ -256,14 +237,13 @@ class BaseActivity(TestCase):
         self.assertEqual(status.mention_hashtags.first(), hashtag)
 
     @responses.activate
-    def test_to_model_one_to_many(self, *_):
+    def test_to_model_one_to_many(self):
         """these are reversed relationships, where the secondary object
         keys the primary object but not vice versa"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Status.objects.create(
-                content="test status",
-                user=self.user,
-            )
+        status = models.Status.objects.create(
+            content="test status",
+            user=self.user,
+        )
         update_data = activitypub.Note(
             id=status.remote_id,
             content=status.content,
@@ -288,22 +268,18 @@ class BaseActivity(TestCase):
         )
 
         # sets the celery task call to the function call
-        with (
-            patch("bookwyrm.activitypub.base_activity.set_related_field.delay"),
-            patch("bookwyrm.models.status.Status.ignore_activity") as discarder,
-        ):
+        with patch("bookwyrm.models.status.Status.ignore_activity") as discarder:
             discarder.return_value = False
             update_data.to_model(model=models.Status, instance=status)
         self.assertIsNone(status.attachments.first())
 
     @responses.activate
-    def test_set_related_field(self, *_):
+    def test_set_related_field(self):
         """celery task to add back-references to created objects"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Status.objects.create(
-                content="test status",
-                user=self.user,
-            )
+        status = models.Status.objects.create(
+            content="test status",
+            user=self.user,
+        )
         data = {
             "url": "http://www.example.com/image.jpg",
             "name": "alt text",

--- a/bookwyrm/tests/activitypub/test_note.py
+++ b/bookwyrm/tests/activitypub/test_note.py
@@ -1,7 +1,5 @@
 """tests functionality specifically for the Note ActivityPub dataclass"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import activitypub
@@ -14,14 +12,9 @@ class Note(TestCase):
     @classmethod
     def setUpTestData(cls):
         """create a shared user"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
+        cls.user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
+        )
         cls.user.remote_id = "https://test-instance.org/user/critic"
         cls.user.save(broadcast=False, update_fields=["remote_id"])
 

--- a/bookwyrm/tests/activitypub/test_person.py
+++ b/bookwyrm/tests/activitypub/test_person.py
@@ -1,6 +1,5 @@
 import json
 import pathlib
-from unittest.mock import patch
 from django.test import TestCase
 
 from bookwyrm import activitypub, models
@@ -19,8 +18,7 @@ class Person(TestCase):
 
     def test_user_to_model(self):
         activity = activitypub.Person(**self.user_data)
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            user = activity.to_model(model=models.User)
+        user = activity.to_model(model=models.User)
         self.assertEqual(user.username, "mouse@example.com")
         self.assertEqual(user.remote_id, "https://example.com/user/mouse")
         self.assertFalse(user.local)

--- a/bookwyrm/tests/activitypub/test_quotation.py
+++ b/bookwyrm/tests/activitypub/test_quotation.py
@@ -2,7 +2,6 @@
 
 import json
 import pathlib
-from unittest.mock import patch
 
 from django.test import TestCase
 from bookwyrm import activitypub, models
@@ -14,16 +13,15 @@ class Quotation(TestCase):
     @classmethod
     def setUpTestData(cls):
         """model objects we'll need"""
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.user = models.User.objects.create_user(
-                "mouse",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=False,
-                inbox="https://example.com/user/mouse/inbox",
-                outbox="https://example.com/user/mouse/outbox",
-                remote_id="https://example.com/user/mouse",
-            )
+        cls.user = models.User.objects.create_user(
+            "mouse",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=False,
+            inbox="https://example.com/user/mouse/inbox",
+            outbox="https://example.com/user/mouse/outbox",
+            remote_id="https://example.com/user/mouse",
+        )
         cls.book = models.Edition.objects.create(
             title="Example Edition",
             remote_id="https://example.com/book/1",

--- a/bookwyrm/tests/activitystreams/test_abstractstream.py
+++ b/bookwyrm/tests/activitystreams/test_abstractstream.py
@@ -7,42 +7,31 @@ from django.test import TestCase
 from bookwyrm import activitystreams, models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """use a test csv"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         work = models.Work.objects.create(title="test work")
         cls.book = models.Edition.objects.create(title="test book", parent_work=work)
 
@@ -56,7 +45,7 @@ class Activitystreams(TestCase):
 
         self.test_stream = TestStream()
 
-    def test_activitystream_class_ids(self, *_):
+    def test_activitystream_class_ids(self):
         """the abstract base class for stream objects"""
         self.assertEqual(
             self.test_stream.stream_id(self.local_user.id),
@@ -67,14 +56,14 @@ class Activitystreams(TestCase):
             f"{self.local_user.id}-test-unread",
         )
 
-    def test_unread_by_status_type_id(self, *_):
+    def test_unread_by_status_type_id(self):
         """stream for status type"""
         self.assertEqual(
             self.test_stream.unread_by_status_type_id(self.local_user.id),
             f"{self.local_user.id}-test-unread-by-type",
         )
 
-    def test_get_rank(self, *_):
+    def test_get_rank(self):
         """sort order"""
         date = datetime(2022, 1, 28, 0, 0, tzinfo=timezone.utc)
         status = models.Status.objects.create(
@@ -88,7 +77,7 @@ class Activitystreams(TestCase):
             "1643328000.0",
         )
 
-    def test_get_activity_stream(self, *_):
+    def test_get_activity_stream(self):
         """load statuses"""
         status = models.Status.objects.create(
             user=self.remote_user,
@@ -119,7 +108,7 @@ class Activitystreams(TestCase):
         self.assertEqual(result.last(), status)
         self.assertIsInstance(result.first(), models.Comment)
 
-    def test_abstractstream_get_audience(self, *_):
+    def test_abstractstream_get_audience(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.remote_user, content="hi", privacy="public"
@@ -130,7 +119,7 @@ class Activitystreams(TestCase):
         self.assertTrue(self.local_user.id in users)
         self.assertTrue(self.another_user.id in users)
 
-    def test_abstractstream_get_audience_direct(self, *_):
+    def test_abstractstream_get_audience_direct(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.remote_user,
@@ -153,7 +142,7 @@ class Activitystreams(TestCase):
         self.assertFalse(self.another_user.id in users)
         self.assertFalse(self.remote_user.id in users)
 
-    def test_abstractstream_get_audience_followers_remote_user(self, *_):
+    def test_abstractstream_get_audience_followers_remote_user(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.remote_user,
@@ -163,7 +152,7 @@ class Activitystreams(TestCase):
         users = self.test_stream.get_audience(status)
         self.assertEqual(users, [])
 
-    def test_abstractstream_get_audience_followers_self(self, *_):
+    def test_abstractstream_get_audience_followers_self(self):
         """get a list of users that should see a status"""
         status = models.Comment.objects.create(
             user=self.local_user,
@@ -176,7 +165,7 @@ class Activitystreams(TestCase):
         self.assertFalse(self.another_user.id in users)
         self.assertFalse(self.remote_user.id in users)
 
-    def test_abstractstream_get_audience_followers_with_mention(self, *_):
+    def test_abstractstream_get_audience_followers_with_mention(self):
         """get a list of users that should see a status"""
         status = models.Comment.objects.create(
             user=self.remote_user,
@@ -191,7 +180,7 @@ class Activitystreams(TestCase):
         self.assertFalse(self.another_user.id in users)
         self.assertFalse(self.remote_user.id in users)
 
-    def test_abstractstream_get_audience_followers_with_relationship(self, *_):
+    def test_abstractstream_get_audience_followers_with_relationship(self):
         """get a list of users that should see a status"""
         self.remote_user.followers.add(self.local_user)
         status = models.Comment.objects.create(

--- a/bookwyrm/tests/activitystreams/test_booksstream.py
+++ b/bookwyrm/tests/activitystreams/test_booksstream.py
@@ -7,39 +7,28 @@ from django.test import TestCase
 from bookwyrm import activitystreams, models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """use a test csv"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         work = models.Work.objects.create(title="test work")
         cls.book = models.Edition.objects.create(title="test book", parent_work=work)
 
-    def test_get_statuses_for_user_books(self, *_):
+    def test_get_statuses_for_user_books(self):
         """create a stream for a user"""
         alt_book = models.Edition.objects.create(
             title="hi", parent_work=self.book.parent_work
@@ -59,7 +48,7 @@ class Activitystreams(TestCase):
         result = activitystreams.BooksStream().get_statuses_for_user(self.local_user)
         self.assertEqual(list(result), [status])
 
-    def test_book_statuses(self, *_):
+    def test_book_statuses(self):
         """statuses about a book"""
         alt_book = models.Edition.objects.create(
             title="hi", parent_work=self.book.parent_work

--- a/bookwyrm/tests/activitystreams/test_homestream.py
+++ b/bookwyrm/tests/activitystreams/test_homestream.py
@@ -1,48 +1,36 @@
 """testing activitystreams"""
 
-from unittest.mock import patch
 from django.test import TestCase
 from bookwyrm import activitystreams, models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """use a test csv"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
-    def test_homestream_get_audience(self, *_):
+    def test_homestream_get_audience(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.remote_user, content="hi", privacy="public"
@@ -50,7 +38,7 @@ class Activitystreams(TestCase):
         users = activitystreams.HomeStream().get_audience(status)
         self.assertEqual(users, [])
 
-    def test_homestream_get_audience_with_mentions(self, *_):
+    def test_homestream_get_audience_with_mentions(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.remote_user, content="hi", privacy="public"
@@ -60,7 +48,7 @@ class Activitystreams(TestCase):
         self.assertFalse(self.local_user.id in users)
         self.assertFalse(self.another_user.id in users)
 
-    def test_homestream_get_audience_with_relationship(self, *_):
+    def test_homestream_get_audience_with_relationship(self):
         """get a list of users that should see a status"""
         self.remote_user.followers.add(self.local_user)
         status = models.Status.objects.create(

--- a/bookwyrm/tests/activitystreams/test_localstream.py
+++ b/bookwyrm/tests/activitystreams/test_localstream.py
@@ -1,50 +1,38 @@
 """testing activitystreams"""
 
-from unittest.mock import patch
 from django.test import TestCase
 from bookwyrm import activitystreams, models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """use a test csv"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         work = models.Work.objects.create(title="test work")
         cls.book = models.Edition.objects.create(title="test book", parent_work=work)
 
-    def test_localstream_get_audience_remote_status(self, *_):
+    def test_localstream_get_audience_remote_status(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.remote_user, content="hi", privacy="public"
@@ -52,7 +40,7 @@ class Activitystreams(TestCase):
         users = activitystreams.LocalStream().get_audience(status)
         self.assertEqual(users, [])
 
-    def test_localstream_get_audience_local_status(self, *_):
+    def test_localstream_get_audience_local_status(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.local_user, content="hi", privacy="public"
@@ -61,7 +49,7 @@ class Activitystreams(TestCase):
         self.assertTrue(self.local_user.id in users)
         self.assertTrue(self.another_user.id in users)
 
-    def test_localstream_get_audience_unlisted(self, *_):
+    def test_localstream_get_audience_unlisted(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.local_user, content="hi", privacy="unlisted"
@@ -69,7 +57,7 @@ class Activitystreams(TestCase):
         users = activitystreams.LocalStream().get_audience(status)
         self.assertEqual(users, [])
 
-    def test_localstream_get_audience_books_no_book(self, *_):
+    def test_localstream_get_audience_books_no_book(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.local_user, content="hi", privacy="public"
@@ -78,7 +66,7 @@ class Activitystreams(TestCase):
         # no books, no audience
         self.assertEqual(audience, [])
 
-    def test_localstream_get_audience_books_mention_books(self, *_):
+    def test_localstream_get_audience_books_mention_books(self):
         """get a list of users that should see a status"""
         status = models.Status.objects.create(
             user=self.local_user, content="hi", privacy="public"
@@ -94,7 +82,7 @@ class Activitystreams(TestCase):
         audience = activitystreams.BooksStream().get_audience(status)
         self.assertTrue(self.local_user.id in audience)
 
-    def test_localstream_get_audience_books_book_field(self, *_):
+    def test_localstream_get_audience_books_book_field(self):
         """get a list of users that should see a status"""
         status = models.Comment.objects.create(
             user=self.local_user, content="hi", privacy="public", book=self.book
@@ -108,7 +96,7 @@ class Activitystreams(TestCase):
         audience = activitystreams.BooksStream().get_audience(status)
         self.assertTrue(self.local_user.id in audience)
 
-    def test_localstream_get_audience_books_alternate_edition(self, *_):
+    def test_localstream_get_audience_books_alternate_edition(self):
         """get a list of users that should see a status"""
         alt_book = models.Edition.objects.create(
             title="hi", parent_work=self.book.parent_work
@@ -125,7 +113,7 @@ class Activitystreams(TestCase):
         audience = activitystreams.BooksStream().get_audience(status)
         self.assertTrue(self.local_user.id in audience)
 
-    def test_localstream_get_audience_books_non_public(self, *_):
+    def test_localstream_get_audience_books_non_public(self):
         """get a list of users that should see a status"""
         alt_book = models.Edition.objects.create(
             title="hi", parent_work=self.book.parent_work

--- a/bookwyrm/tests/activitystreams/test_signals.py
+++ b/bookwyrm/tests/activitystreams/test_signals.py
@@ -9,51 +9,41 @@ from django.utils import timezone
 from bookwyrm import activitystreams, models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.lists_stream.add_user_lists_task.delay")
-@patch("bookwyrm.lists_stream.remove_user_lists_task.delay")
 class ActivitystreamsSignals(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """use a test csv"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
-    def test_add_status_on_create_ignore(self, *_):
+    def test_add_status_on_create_ignore(self):
         """a new statuses has entered"""
         activitystreams.add_status_on_create(models.User, self.local_user, False)
 
-    def test_add_status_on_create_deleted(self, *_):
+    def test_add_status_on_create_deleted(self):
         """a new statuses has entered"""
-        with patch("bookwyrm.activitystreams.remove_status_task.delay"):
-            status = models.Status.objects.create(
-                user=self.remote_user, content="hi", privacy="public", deleted=True
-            )
+        status = models.Status.objects.create(
+            user=self.remote_user, content="hi", privacy="public", deleted=True
+        )
         with patch("bookwyrm.activitystreams.remove_status_task.delay") as mock:
             activitystreams.add_status_on_create(models.Status, status, False)
         self.assertEqual(mock.call_count, 1)
         args = mock.call_args[0]
         self.assertEqual(args[0], status.id)
 
-    def test_add_status_on_create_created(self, *_):
+    def test_add_status_on_create_created(self):
         """a new statuses has entered"""
         status = models.Status.objects.create(
             user=self.remote_user, content="hi", privacy="public"
@@ -65,7 +55,7 @@ class ActivitystreamsSignals(TestCase):
         self.assertEqual(args["args"][0], status.id)
         self.assertEqual(args["queue"], "streams")
 
-    def test_add_status_on_create_created_low_priority(self, *_):
+    def test_add_status_on_create_created_low_priority(self):
         """a new statuses has entered"""
         # created later than publication
         status = models.Status.objects.create(
@@ -98,7 +88,7 @@ class ActivitystreamsSignals(TestCase):
         self.assertEqual(args["args"][0], status.id)
         self.assertEqual(args["queue"], "import_triggered")
 
-    def test_populate_streams_on_account_create_command(self, *_):
+    def test_populate_streams_on_account_create_command(self):
         """create streams for a user"""
         with patch("bookwyrm.activitystreams.populate_stream_task.delay") as mock:
             activitystreams.populate_streams_on_account_create_command(
@@ -109,7 +99,7 @@ class ActivitystreamsSignals(TestCase):
         self.assertEqual(args[0], "books")
         self.assertEqual(args[1], self.local_user.id)
 
-    def test_remove_statuses_on_block(self, *_):
+    def test_remove_statuses_on_block(self):
         """don't show statuses from blocked users"""
         with patch("bookwyrm.activitystreams.remove_user_statuses_task.delay") as mock:
             models.UserBlocks.objects.create(
@@ -121,13 +111,12 @@ class ActivitystreamsSignals(TestCase):
         self.assertEqual(args[0], self.local_user.id)
         self.assertEqual(args[1], self.remote_user.id)
 
-    def test_add_statuses_on_unblock(self, *_):
+    def test_add_statuses_on_unblock(self):
         """re-add statuses on unblock"""
-        with patch("bookwyrm.activitystreams.remove_user_statuses_task.delay"):
-            block = models.UserBlocks.objects.create(
-                user_subject=self.local_user,
-                user_object=self.remote_user,
-            )
+        block = models.UserBlocks.objects.create(
+            user_subject=self.local_user,
+            user_object=self.remote_user,
+        )
 
         with patch("bookwyrm.activitystreams.add_user_statuses_task.delay") as mock:
             block.delete()
@@ -138,17 +127,16 @@ class ActivitystreamsSignals(TestCase):
         self.assertEqual(args[1], self.remote_user.id)
         self.assertEqual(kwargs["stream_list"], ["local", "books"])
 
-    def test_add_statuses_on_unblock_reciprocal_block(self, *_):
+    def test_add_statuses_on_unblock_reciprocal_block(self):
         """re-add statuses on unblock"""
-        with patch("bookwyrm.activitystreams.remove_user_statuses_task.delay"):
-            block = models.UserBlocks.objects.create(
-                user_subject=self.local_user,
-                user_object=self.remote_user,
-            )
-            block = models.UserBlocks.objects.create(
-                user_subject=self.remote_user,
-                user_object=self.local_user,
-            )
+        block = models.UserBlocks.objects.create(
+            user_subject=self.local_user,
+            user_object=self.remote_user,
+        )
+        block = models.UserBlocks.objects.create(
+            user_subject=self.remote_user,
+            user_object=self.local_user,
+        )
 
         with patch("bookwyrm.activitystreams.add_user_statuses_task.delay") as mock:
             block.delete()

--- a/bookwyrm/tests/activitystreams/test_tasks.py
+++ b/bookwyrm/tests/activitystreams/test_tasks.py
@@ -11,35 +11,28 @@ class Activitystreams(TestCase):
     @classmethod
     def setUpTestData(cls):
         """use a test csv"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         work = models.Work.objects.create(title="test work")
         cls.book = models.Edition.objects.create(title="test book", parent_work=work)
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            cls.status = models.Status.objects.create(content="hi", user=cls.local_user)
+        cls.status = models.Status.objects.create(content="hi", user=cls.local_user)
 
     def test_add_book_statuses_task(self):
         """statuses related to a book"""
@@ -133,20 +126,19 @@ class Activitystreams(TestCase):
         self.assertEqual(args[0], self.local_user)
         self.assertEqual(args[1], self.another_user)
 
-    @patch("bookwyrm.activitystreams.LocalStream.remove_object_from_stores")
-    @patch("bookwyrm.activitystreams.BooksStream.remove_object_from_stores")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_boost_to_another_timeline(self, *_):
+    def test_boost_to_another_timeline(self):
         """boost from a non-follower doesn't remove original status from feed"""
         status = models.Status.objects.create(user=self.local_user, content="hi")
-        with patch("bookwyrm.activitystreams.handle_boost_task.delay"):
-            boost = models.Boost.objects.create(
-                boosted_status=status,
-                user=self.another_user,
-            )
-        with patch(
-            "bookwyrm.activitystreams.HomeStream.remove_object_from_stores"
-        ) as mock:
+        boost = models.Boost.objects.create(
+            boosted_status=status,
+            user=self.another_user,
+        )
+        with (
+            patch("bookwyrm.activitystreams.LocalStream.remove_object_from_stores"),
+            patch(
+                "bookwyrm.activitystreams.HomeStream.remove_object_from_stores"
+            ) as mock,
+        ):
             activitystreams.handle_boost_task(boost.id)
 
         self.assertTrue(mock.called)
@@ -155,20 +147,19 @@ class Activitystreams(TestCase):
         self.assertEqual(call_args[0][0], status)
         self.assertEqual(call_args[0][1], [f"{self.another_user.id}-home"])
 
-    @patch("bookwyrm.activitystreams.LocalStream.remove_object_from_stores")
-    @patch("bookwyrm.activitystreams.BooksStream.remove_object_from_stores")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_boost_to_another_timeline_remote(self, *_):
+    def test_boost_to_another_timeline_remote(self):
         """boost from a remote non-follower doesn't remove original status from feed"""
         status = models.Status.objects.create(user=self.local_user, content="hi")
-        with patch("bookwyrm.activitystreams.handle_boost_task.delay"):
-            boost = models.Boost.objects.create(
-                boosted_status=status,
-                user=self.remote_user,
-            )
-        with patch(
-            "bookwyrm.activitystreams.HomeStream.remove_object_from_stores"
-        ) as mock:
+        boost = models.Boost.objects.create(
+            boosted_status=status,
+            user=self.remote_user,
+        )
+        with (
+            patch("bookwyrm.activitystreams.LocalStream.remove_object_from_stores"),
+            patch(
+                "bookwyrm.activitystreams.HomeStream.remove_object_from_stores"
+            ) as mock,
+        ):
             activitystreams.handle_boost_task(boost.id)
 
         self.assertTrue(mock.called)
@@ -177,21 +168,20 @@ class Activitystreams(TestCase):
         self.assertEqual(call_args[0][0], status)
         self.assertEqual(call_args[0][1], [])
 
-    @patch("bookwyrm.activitystreams.LocalStream.remove_object_from_stores")
-    @patch("bookwyrm.activitystreams.BooksStream.remove_object_from_stores")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_boost_to_following_timeline(self, *_):
+    def test_boost_to_following_timeline(self):
         """add a boost and deduplicate the boosted status on the timeline"""
         self.local_user.following.add(self.another_user)
         status = models.Status.objects.create(user=self.local_user, content="hi")
-        with patch("bookwyrm.activitystreams.handle_boost_task.delay"):
-            boost = models.Boost.objects.create(
-                boosted_status=status,
-                user=self.another_user,
-            )
-        with patch(
-            "bookwyrm.activitystreams.HomeStream.remove_object_from_stores"
-        ) as mock:
+        boost = models.Boost.objects.create(
+            boosted_status=status,
+            user=self.another_user,
+        )
+        with (
+            patch("bookwyrm.activitystreams.LocalStream.remove_object_from_stores"),
+            patch(
+                "bookwyrm.activitystreams.HomeStream.remove_object_from_stores"
+            ) as mock,
+        ):
             activitystreams.handle_boost_task(boost.id)
         self.assertTrue(mock.called)
         call_args = mock.call_args
@@ -199,20 +189,19 @@ class Activitystreams(TestCase):
         self.assertTrue(f"{self.another_user.id}-home" in call_args[0][1])
         self.assertTrue(f"{self.local_user.id}-home" in call_args[0][1])
 
-    @patch("bookwyrm.activitystreams.LocalStream.remove_object_from_stores")
-    @patch("bookwyrm.activitystreams.BooksStream.remove_object_from_stores")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_boost_to_same_timeline(self, *_):
+    def test_boost_to_same_timeline(self):
         """add a boost and deduplicate the boosted status on the timeline"""
         status = models.Status.objects.create(user=self.local_user, content="hi")
-        with patch("bookwyrm.activitystreams.handle_boost_task.delay"):
-            boost = models.Boost.objects.create(
-                boosted_status=status,
-                user=self.local_user,
-            )
-        with patch(
-            "bookwyrm.activitystreams.HomeStream.remove_object_from_stores"
-        ) as mock:
+        boost = models.Boost.objects.create(
+            boosted_status=status,
+            user=self.local_user,
+        )
+        with (
+            patch("bookwyrm.activitystreams.LocalStream.remove_object_from_stores"),
+            patch(
+                "bookwyrm.activitystreams.HomeStream.remove_object_from_stores"
+            ) as mock,
+        ):
             activitystreams.handle_boost_task(boost.id)
         self.assertTrue(mock.called)
         call_args = mock.call_args

--- a/bookwyrm/tests/connectors/test_abstract_connector.py
+++ b/bookwyrm/tests/connectors/test_abstract_connector.py
@@ -1,6 +1,5 @@
 """testing book data connectors"""
 
-from unittest.mock import patch
 from django.test import TestCase
 import responses
 
@@ -107,8 +106,7 @@ class AbstractConnector(TestCase):
         responses.add(
             responses.GET, "https://example.com/book/abcd", json=self.edition_data
         )
-        with patch("bookwyrm.connectors.abstract_connector.load_more_data.delay"):
-            result = self.connector.get_or_create_book("https://example.com/book/abcd")
+        result = self.connector.get_or_create_book("https://example.com/book/abcd")
         self.assertEqual(result, self.book)
         self.assertEqual(models.Edition.objects.count(), 1)
         self.assertEqual(models.Edition.objects.count(), 1)

--- a/bookwyrm/tests/importers/test_bookwyrm_import.py
+++ b/bookwyrm/tests/importers/test_bookwyrm_import.py
@@ -1,7 +1,6 @@
 """testing bookwyrm csv import"""
 
 import pathlib
-from unittest.mock import patch
 import datetime
 
 from django.test import TestCase
@@ -16,9 +15,6 @@ def make_date(*args):
     return datetime.datetime(*args, tzinfo=datetime.timezone.utc)
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class BookwyrmBooksImport(TestCase):
     """importing from BookWyrm csv"""
 
@@ -36,14 +32,9 @@ class BookwyrmBooksImport(TestCase):
     @classmethod
     def setUpTestData(cls):
         """populate database"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -51,7 +42,7 @@ class BookwyrmBooksImport(TestCase):
             parent_work=work,
         )
 
-    def test_create_job(self, *_):
+    def test_create_job(self):
         """creates the import job entry and checks csv"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
@@ -76,7 +67,7 @@ class BookwyrmBooksImport(TestCase):
         self.assertEqual(import_items[2].normalized_data["isbn_10"], "0375503129")
         self.assertEqual(import_items[2].shelf_name, "Read")
 
-    def test_create_retry_job(self, *_):
+    def test_create_retry_job(self):
         """trying again with items that didn't import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
@@ -100,7 +91,7 @@ class BookwyrmBooksImport(TestCase):
         self.assertEqual(retry_items[1].index, 1)
         self.assertEqual(retry_items[1].data["author_text"], "Yotam Ottolenghi")
 
-    def test_handle_imported_book(self, *_):
+    def test_handle_imported_book(self):
         """import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.READ_FINISHED
@@ -114,8 +105,7 @@ class BookwyrmBooksImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
@@ -128,7 +118,7 @@ class BookwyrmBooksImport(TestCase):
         self.assertEqual(readthrough.start_date, make_date(2001, 6, 1))
         self.assertEqual(readthrough.finish_date, make_date(2001, 7, 10))
 
-    def test_create_new_shelf(self, *_):
+    def test_create_new_shelf(self):
         """import added a book, was a new shelf created?"""
         shelf = self.local_user.shelf_set.filter(identifier="cooking").first()
         self.assertIsNone(shelf)
@@ -142,14 +132,12 @@ class BookwyrmBooksImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf_after = self.local_user.shelf_set.filter(identifier="cooking-9").first()
         self.assertEqual(shelf_after.books.first(), self.book)
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_review(self, *_):
+    def test_handle_imported_book_review(self):
         """review import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -158,8 +146,7 @@ class BookwyrmBooksImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.Review.objects.get(book=self.book, user=self.local_user)
         self.assertEqual(review.name, "Too much tahini")
@@ -168,8 +155,7 @@ class BookwyrmBooksImport(TestCase):
         self.assertEqual(review.published_date, make_date(2022, 11, 10))
         self.assertEqual(review.privacy, "unlisted")
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_rating(self, *_):
+    def test_handle_imported_book_rating(self):
         """rating import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "followers"
@@ -178,8 +164,7 @@ class BookwyrmBooksImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.ReviewRating.objects.get(book=self.book, user=self.local_user)
         self.assertIsInstance(review, models.ReviewRating)

--- a/bookwyrm/tests/importers/test_bookwyrm_user_import.py
+++ b/bookwyrm/tests/importers/test_bookwyrm_user_import.py
@@ -1,6 +1,5 @@
 """testing bookwyrm user import"""
 
-from unittest.mock import patch
 from django.test import TestCase
 from bookwyrm import models
 from bookwyrm.importers import BookwyrmImporter
@@ -11,15 +10,9 @@ class BookwyrmUserImport(TestCase):
 
     def setUp(self):
         """setting stuff up"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
-        ):
-            self.user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
+        self.user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
 
     def test_create_retry_job(self):
         """test retrying a user import"""

--- a/bookwyrm/tests/importers/test_calibre_import.py
+++ b/bookwyrm/tests/importers/test_calibre_import.py
@@ -1,8 +1,6 @@
 """testing import"""
 
 import pathlib
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import models
@@ -10,9 +8,6 @@ from bookwyrm.importers import CalibreImporter
 from bookwyrm.models.import_job import handle_imported_book
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class CalibreImport(TestCase):
     """importing from Calibre csv"""
 
@@ -30,14 +25,9 @@ class CalibreImport(TestCase):
     @classmethod
     def setUpTestData(cls):
         """populate database"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -45,7 +35,7 @@ class CalibreImport(TestCase):
             parent_work=work,
         )
 
-    def test_create_job(self, *_):
+    def test_create_job(self):
         """creates the import job entry and checks csv"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
@@ -63,7 +53,7 @@ class CalibreImport(TestCase):
             import_items[0].normalized_data["title"], "That Ain't Witchcraft"
         )
 
-    def test_handle_imported_book(self, *_):
+    def test_handle_imported_book(self):
         """calibre import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.TO_READ
@@ -77,8 +67,7 @@ class CalibreImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)

--- a/bookwyrm/tests/importers/test_goodreads_import.py
+++ b/bookwyrm/tests/importers/test_goodreads_import.py
@@ -1,7 +1,6 @@
 """testing import"""
 
 import pathlib
-from unittest.mock import patch
 import datetime
 
 from django.test import TestCase
@@ -16,9 +15,6 @@ def make_date(*args):
     return datetime.datetime(*args, tzinfo=datetime.timezone.utc)
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class GoodreadsImport(TestCase):
     """importing from goodreads csv"""
 
@@ -36,14 +32,9 @@ class GoodreadsImport(TestCase):
     @classmethod
     def setUpTestData(cls):
         """populate database"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -51,7 +42,7 @@ class GoodreadsImport(TestCase):
             parent_work=work,
         )
 
-    def test_create_job(self, *_):
+    def test_create_job(self):
         """creates the import job entry and checks csv"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
@@ -72,7 +63,7 @@ class GoodreadsImport(TestCase):
         self.assertEqual(import_items[2].index, 2)
         self.assertEqual(import_items[2].data["Book Id"], "28694510")
 
-    def test_create_retry_job(self, *_):
+    def test_create_retry_job(self):
         """trying again with items that didn't import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
@@ -96,7 +87,7 @@ class GoodreadsImport(TestCase):
         self.assertEqual(retry_items[1].index, 1)
         self.assertEqual(retry_items[1].data["Book Id"], "52691223")
 
-    def test_handle_imported_book(self, *_):
+    def test_handle_imported_book(self):
         """goodreads import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.READ_FINISHED
@@ -110,8 +101,7 @@ class GoodreadsImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
@@ -124,8 +114,7 @@ class GoodreadsImport(TestCase):
         self.assertEqual(readthrough.start_date, make_date(2020, 10, 21))
         self.assertEqual(readthrough.finish_date, make_date(2020, 10, 25))
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_review(self, *_):
+    def test_handle_imported_book_review(self):
         """goodreads review import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -134,8 +123,7 @@ class GoodreadsImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.Review.objects.get(book=self.book, user=self.local_user)
         self.assertEqual(review.content, "mixed feelings")
@@ -143,8 +131,7 @@ class GoodreadsImport(TestCase):
         self.assertEqual(review.published_date, make_date(2019, 7, 8))
         self.assertEqual(review.privacy, "unlisted")
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_rating(self, *_):
+    def test_handle_imported_book_rating(self):
         """goodreads rating import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -153,8 +140,7 @@ class GoodreadsImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.ReviewRating.objects.get(book=self.book, user=self.local_user)
         self.assertIsInstance(review, models.ReviewRating)

--- a/bookwyrm/tests/importers/test_importer.py
+++ b/bookwyrm/tests/importers/test_importer.py
@@ -20,9 +20,6 @@ def make_date(*args):
     return datetime.datetime(*args, tzinfo=datetime.timezone.utc)
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class GenericImporter(TestCase):
     """importing from csv"""
 
@@ -40,14 +37,9 @@ class GenericImporter(TestCase):
     @classmethod
     def setUpTestData(cls):
         """populate database"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -55,7 +47,7 @@ class GenericImporter(TestCase):
             parent_work=work,
         )
 
-    def test_create_job(self, *_):
+    def test_create_job(self):
         """creates the import job entry and checks csv"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
@@ -88,7 +80,7 @@ class GenericImporter(TestCase):
         self.assertEqual(import_items[3].normalized_data["id"], "10")
         self.assertEqual(import_items[3].normalized_data["title"], "Patisserie at Home")
 
-    def test_create_retry_job(self, *_):
+    def test_create_retry_job(self):
         """trying again with items that didn't import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
@@ -112,27 +104,29 @@ class GenericImporter(TestCase):
         self.assertEqual(retry_items[1].index, 1)
         self.assertEqual(retry_items[1].normalized_data["id"], "48")
 
-    def test_start_import(self, *_):
+    def test_start_import(self):
         """check that a task was created"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
         )
         MockTask = namedtuple("Task", ("id"))
+
         with patch("bookwyrm.models.import_job.start_import_task.delay") as mock:
             mock.return_value = MockTask(123)
             import_job.start_job()
+
         self.assertEqual(mock.call_count, 1)
         import_job.refresh_from_db()
         self.assertEqual(import_job.task_id, "123")
 
     @responses.activate
-    def test_start_import_task(self, *_):
+    def test_start_import_task(self):
         """resolve entry"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
         )
-
         MockTask = namedtuple("Task", ("id"))
+
         with patch("bookwyrm.models.import_job.import_item_task.delay") as mock:
             mock.return_value = MockTask(123)
             start_import_task(import_job.id)
@@ -140,27 +134,29 @@ class GenericImporter(TestCase):
         self.assertEqual(mock.call_count, 4)
 
     @responses.activate
-    def test_import_item_task(self, *_):
+    def test_import_item_task(self):
         """resolve entry"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
         )
-
         import_item = models.ImportItem.objects.get(job=import_job, index=0)
-        with patch(
-            "bookwyrm.models.import_job.ImportItem.get_book_from_identifier"
-        ) as resolve:
-            resolve.return_value = self.book
 
-            with patch(
+        with (
+            patch(
+                "bookwyrm.models.import_job.ImportItem.get_book_from_identifier"
+            ) as resolve,
+            patch(
                 "bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"
-            ) as mock:
-                import_item_task(import_item.id)
-                kwargs = mock.call_args.kwargs
+            ) as mock,
+        ):
+            resolve.return_value = self.book
+            import_item_task(import_item.id)
+            kwargs = mock.call_args.kwargs
+
         self.assertEqual(kwargs["queue"], "import_triggered")
         import_item.refresh_from_db()
 
-    def test_complete_job(self, *_):
+    def test_complete_job(self):
         """test notification"""
 
         # csv content not important
@@ -181,7 +177,7 @@ class GenericImporter(TestCase):
             ).exists()
         )
 
-    def test_handle_imported_book(self, *_):
+    def test_handle_imported_book(self):
         """import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.READ_FINISHED
@@ -195,25 +191,22 @@ class GenericImporter(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
 
-    def test_handle_imported_book_already_shelved(self, *_):
+    def test_handle_imported_book_already_shelved(self):
         """import added a book, this adds related connections"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            shelf = self.local_user.shelf_set.filter(
-                identifier=models.Shelf.TO_READ
-            ).first()
-            models.ShelfBook.objects.create(
-                shelf=shelf,
-                user=self.local_user,
-                book=self.book,
-                shelved_date=make_date(2020, 2, 2),
-            )
-
+        shelf = self.local_user.shelf_set.filter(
+            identifier=models.Shelf.TO_READ
+        ).first()
+        models.ShelfBook.objects.create(
+            shelf=shelf,
+            user=self.local_user,
+            book=self.book,
+            shelved_date=make_date(2020, 2, 2),
+        )
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
         )
@@ -221,8 +214,7 @@ class GenericImporter(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
@@ -235,7 +227,7 @@ class GenericImporter(TestCase):
             ).books.first()
         )
 
-    def test_handle_import_twice(self, *_):
+    def test_handle_import_twice(self):
         """re-importing books"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.READ_FINISHED
@@ -247,16 +239,14 @@ class GenericImporter(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
         self.assertEqual(models.ReadThrough.objects.count(), 1)
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_review(self, *_):
+    def test_handle_imported_book_review(self):
         """review import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -265,11 +255,9 @@ class GenericImporter(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.models.Status.broadcast") as broadcast_mock,
-        ):
+        with patch("bookwyrm.models.Status.broadcast") as broadcast_mock:
             handle_imported_book(import_item)
+
         kwargs = broadcast_mock.call_args.kwargs
         self.assertEqual(kwargs["software"], "bookwyrm")
         review = models.Review.objects.get(book=self.book, user=self.local_user)
@@ -280,8 +268,7 @@ class GenericImporter(TestCase):
         import_item.refresh_from_db()
         self.assertEqual(import_item.linked_review, review)
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_rating(self, *_):
+    def test_handle_imported_book_rating(self):
         """rating import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -290,29 +277,7 @@ class GenericImporter(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
-        review = models.ReviewRating.objects.get(book=self.book, user=self.local_user)
-        self.assertIsInstance(review, models.ReviewRating)
-        self.assertEqual(review.rating, 3.0)
-        self.assertEqual(review.privacy, "unlisted")
-
-        import_item.refresh_from_db()
-        self.assertEqual(import_item.linked_review.id, review.id)
-
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_rating_duplicate_with_link(self, *_):
-        """rating import twice"""
-        import_job = self.importer.create_job(
-            self.local_user, self.csv, True, "unlisted"
-        )
-        import_item = import_job.items.filter(index=1).first()
-        import_item.book = self.book
-        import_item.save()
-
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.ReviewRating.objects.get(book=self.book, user=self.local_user)
         self.assertIsInstance(review, models.ReviewRating)
@@ -322,8 +287,7 @@ class GenericImporter(TestCase):
         import_item.refresh_from_db()
         self.assertEqual(import_item.linked_review.id, review.id)
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_rating_duplicate_without_link(self, *_):
+    def test_handle_imported_book_rating_duplicate_with_link(self):
         """rating import twice"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -332,14 +296,33 @@ class GenericImporter(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
+        handle_imported_book(import_item)
+
+        review = models.ReviewRating.objects.get(book=self.book, user=self.local_user)
+        self.assertIsInstance(review, models.ReviewRating)
+        self.assertEqual(review.rating, 3.0)
+        self.assertEqual(review.privacy, "unlisted")
+
+        import_item.refresh_from_db()
+        self.assertEqual(import_item.linked_review.id, review.id)
+
+    def test_handle_imported_book_rating_duplicate_without_link(self):
+        """rating import twice"""
+        import_job = self.importer.create_job(
+            self.local_user, self.csv, True, "unlisted"
+        )
+        import_item = import_job.items.filter(index=1).first()
+        import_item.book = self.book
+        import_item.save()
+
+        handle_imported_book(import_item)
+
         import_item.refresh_from_db()
         import_item.linked_review = None
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.ReviewRating.objects.get(book=self.book, user=self.local_user)
         self.assertIsInstance(review, models.ReviewRating)
@@ -349,7 +332,7 @@ class GenericImporter(TestCase):
         import_item.refresh_from_db()
         self.assertEqual(import_item.linked_review.id, review.id)
 
-    def test_handle_imported_book_reviews_disabled(self, *_):
+    def test_handle_imported_book_reviews_disabled(self):
         """review import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
@@ -358,13 +341,13 @@ class GenericImporter(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
+
         self.assertFalse(
             models.Review.objects.filter(book=self.book, user=self.local_user).exists()
         )
 
-    def test_import_limit(self, *_):
+    def test_import_limit(self):
         """checks if import limit works"""
         site_settings = models.SiteSettings.get()
         site_settings.import_size_limit = 2

--- a/bookwyrm/tests/importers/test_librarything_import.py
+++ b/bookwyrm/tests/importers/test_librarything_import.py
@@ -1,7 +1,6 @@
 """testing import"""
 
 import pathlib
-from unittest.mock import patch
 import datetime
 
 from django.test import TestCase
@@ -16,9 +15,6 @@ def make_date(*args):
     return datetime.datetime(*args, tzinfo=datetime.timezone.utc)
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class LibrarythingImport(TestCase):
     """importing from librarything tsv"""
 
@@ -38,14 +34,9 @@ class LibrarythingImport(TestCase):
     @classmethod
     def setUpTestData(cls):
         """populate database"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mmai", "mmai@mmai.mmai", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mmai", "mmai@mmai.mmai", "password", local=True
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -53,7 +44,7 @@ class LibrarythingImport(TestCase):
             parent_work=work,
         )
 
-    def test_create_job(self, *_):
+    def test_create_job(self):
         """creates the import job entry and checks csv"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
@@ -81,7 +72,7 @@ class LibrarythingImport(TestCase):
         self.assertEqual(import_items[2].index, 2)
         self.assertEqual(import_items[2].data["Book Id"], "5015399")
 
-    def test_create_retry_job(self, *_):
+    def test_create_retry_job(self):
         """trying again with items that didn't import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
@@ -105,7 +96,7 @@ class LibrarythingImport(TestCase):
         self.assertEqual(retry_items[1].index, 1)
         self.assertEqual(retry_items[1].data["Book Id"], "5015319")
 
-    def test_handle_imported_book(self, *_):
+    def test_handle_imported_book(self):
         """librarything import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.READ_FINISHED
@@ -119,8 +110,7 @@ class LibrarythingImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
@@ -130,16 +120,14 @@ class LibrarythingImport(TestCase):
         self.assertEqual(readthrough.start_date, make_date(2007, 4, 16))
         self.assertEqual(readthrough.finish_date, make_date(2007, 5, 8))
 
-    def test_handle_imported_book_already_shelved(self, *_):
+    def test_handle_imported_book_already_shelved(self):
         """librarything import added a book, this adds related connections"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            shelf = self.local_user.shelf_set.filter(
-                identifier=models.Shelf.TO_READ
-            ).first()
-            models.ShelfBook.objects.create(
-                shelf=shelf, user=self.local_user, book=self.book
-            )
-
+        shelf = self.local_user.shelf_set.filter(
+            identifier=models.Shelf.TO_READ
+        ).first()
+        models.ShelfBook.objects.create(
+            shelf=shelf, user=self.local_user, book=self.book
+        )
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
         )
@@ -147,8 +135,7 @@ class LibrarythingImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
@@ -163,8 +150,7 @@ class LibrarythingImport(TestCase):
         self.assertEqual(readthrough.start_date, make_date(2007, 4, 16))
         self.assertEqual(readthrough.finish_date, make_date(2007, 5, 8))
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_review(self, *_):
+    def test_handle_imported_book_review(self):
         """librarything review import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -173,8 +159,7 @@ class LibrarythingImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.Review.objects.get(book=self.book, user=self.local_user)
         self.assertEqual(review.content, "chef d'oeuvre")

--- a/bookwyrm/tests/importers/test_openlibrary_import.py
+++ b/bookwyrm/tests/importers/test_openlibrary_import.py
@@ -1,7 +1,6 @@
 """testing import"""
 
 import pathlib
-from unittest.mock import patch
 import datetime
 
 from django.test import TestCase
@@ -16,9 +15,6 @@ def make_date(*args):
     return datetime.datetime(*args, tzinfo=datetime.timezone.utc)
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class OpenLibraryImport(TestCase):
     """importing from openlibrary csv"""
 
@@ -36,14 +32,9 @@ class OpenLibraryImport(TestCase):
     @classmethod
     def setUpTestData(cls):
         """populate database"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -51,7 +42,7 @@ class OpenLibraryImport(TestCase):
             parent_work=work,
         )
 
-    def test_create_job(self, *_):
+    def test_create_job(self):
         """creates the import job entry and checks csv"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
@@ -77,7 +68,7 @@ class OpenLibraryImport(TestCase):
         self.assertEqual(import_items[2].normalized_data["shelf"], "to-read")
         self.assertEqual(import_items[3].normalized_data["shelf"], "read")
 
-    def test_handle_imported_book(self, *_):
+    def test_handle_imported_book(self):
         """openlibrary import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.READING
@@ -91,8 +82,7 @@ class OpenLibraryImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)

--- a/bookwyrm/tests/importers/test_openreads_import.py
+++ b/bookwyrm/tests/importers/test_openreads_import.py
@@ -1,7 +1,6 @@
 """testing import"""
 
 import pathlib
-from unittest.mock import patch
 import datetime
 
 from django.test import TestCase
@@ -16,9 +15,6 @@ def make_date(*args):
     return datetime.datetime(*args, tzinfo=datetime.timezone.utc)
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class OpenReadsImport(TestCase):
     """importing from openreads csv"""
 
@@ -38,14 +34,9 @@ class OpenReadsImport(TestCase):
     @classmethod
     def setUpTestData(cls):
         """populate database"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mmai", "mmai@mmai.mmai", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mmai", "mmai@mmai.mmai", "password", local=True
+        )
         models.SiteSettings.objects.create()
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
@@ -54,7 +45,7 @@ class OpenReadsImport(TestCase):
             parent_work=work,
         )
 
-    def test_create_job(self, *_):
+    def test_create_job(self):
         """creates the import job entry and checks csv"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
@@ -95,7 +86,7 @@ class OpenReadsImport(TestCase):
         self.assertEqual(import_items[3].normalized_data["date_finished"], "2023-11-15")
         self.assertEqual(import_items[3].normalized_data["shelf"], "read")
 
-    def test_create_retry_job(self, *_):
+    def test_create_retry_job(self):
         """trying again with items that didn't import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "unlisted"
@@ -117,7 +108,7 @@ class OpenReadsImport(TestCase):
         self.assertEqual(retry_items[0].data["title"], "Wild Flowers Electric Beasts")
         self.assertEqual(retry_items[1].data["title"], "Permanent Record")
 
-    def test_handle_imported_book(self, *_):
+    def test_handle_imported_book(self):
         """openreads import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.READ_FINISHED
@@ -131,8 +122,7 @@ class OpenReadsImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
@@ -142,16 +132,14 @@ class OpenReadsImport(TestCase):
         self.assertEqual(readthrough.start_date, make_date(2023, 10, 27))
         self.assertEqual(readthrough.finish_date, make_date(2023, 11, 28))
 
-    def test_handle_imported_book_already_shelved(self, *_):
+    def test_handle_imported_book_already_shelved(self):
         """openreads import added a book, this adds related connections"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            shelf = self.local_user.shelf_set.filter(
-                identifier=models.Shelf.TO_READ
-            ).first()
-            models.ShelfBook.objects.create(
-                shelf=shelf, user=self.local_user, book=self.book
-            )
-
+        shelf = self.local_user.shelf_set.filter(
+            identifier=models.Shelf.TO_READ
+        ).first()
+        models.ShelfBook.objects.create(
+            shelf=shelf, user=self.local_user, book=self.book
+        )
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
         )
@@ -159,8 +147,7 @@ class OpenReadsImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
@@ -175,8 +162,7 @@ class OpenReadsImport(TestCase):
         self.assertEqual(readthrough.start_date, make_date(2023, 10, 27))
         self.assertEqual(readthrough.finish_date, make_date(2023, 11, 28))
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_review(self, *_):
+    def test_handle_imported_book_review(self):
         """openreads review import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -185,8 +171,7 @@ class OpenReadsImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.Review.objects.get(book=self.book, user=self.local_user)
         self.assertEqual(review.rating, 4)

--- a/bookwyrm/tests/importers/test_storygraph_import.py
+++ b/bookwyrm/tests/importers/test_storygraph_import.py
@@ -1,7 +1,6 @@
 """testing import"""
 
 import pathlib
-from unittest.mock import patch
 import datetime
 
 from django.test import TestCase
@@ -16,9 +15,6 @@ def make_date(*args):
     return datetime.datetime(*args, tzinfo=datetime.timezone.utc)
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class StorygraphImport(TestCase):
     """importing from storygraph csv"""
 
@@ -36,14 +32,9 @@ class StorygraphImport(TestCase):
     @classmethod
     def setUpTestData(cls):
         """populate database"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -51,7 +42,7 @@ class StorygraphImport(TestCase):
             parent_work=work,
         )
 
-    def test_create_job(self, *_):
+    def test_create_job(self):
         """creates the import job entry and checks csv"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, False, "public"
@@ -75,7 +66,7 @@ class StorygraphImport(TestCase):
         self.assertEqual(subprime_book.normalized_data["rating"], "5.0")
         self.assertEqual(subprime_book.isbn, "0374538654")
 
-    def test_handle_imported_book(self, *_):
+    def test_handle_imported_book(self):
         """storygraph import added a book, this adds related connections"""
         shelf = self.local_user.shelf_set.filter(
             identifier=models.Shelf.TO_READ
@@ -89,8 +80,7 @@ class StorygraphImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         shelf.refresh_from_db()
         self.assertEqual(shelf.books.first(), self.book)
@@ -98,8 +88,7 @@ class StorygraphImport(TestCase):
             shelf.shelfbook_set.first().shelved_date, make_date(2021, 5, 10)
         )
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_handle_imported_book_rating(self, *_):
+    def test_handle_imported_book_rating(self):
         """storygraph rating import"""
         import_job = self.importer.create_job(
             self.local_user, self.csv, True, "unlisted"
@@ -108,8 +97,7 @@ class StorygraphImport(TestCase):
         import_item.book = self.book
         import_item.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            handle_imported_book(import_item)
+        handle_imported_book(import_item)
 
         review = models.ReviewRating.objects.get(book=self.book, user=self.local_user)
         self.assertIsInstance(review, models.ReviewRating)

--- a/bookwyrm/tests/lists_stream/test_signals.py
+++ b/bookwyrm/tests/lists_stream/test_signals.py
@@ -5,59 +5,50 @@ from django.test import TestCase
 from bookwyrm import lists_stream, models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class ListsStreamSignals(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """database setup"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "fish", "fish@fish.fish", "password", local=True, localname="fish"
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "fish", "fish@fish.fish", "password", local=True, localname="fish"
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
-    def test_add_list_on_create_command(self, _):
+    def test_add_list_on_create_command(self):
         """a new lists has entered"""
-        with patch("bookwyrm.lists_stream.remove_list_task.delay"):
-            book_list = models.List.objects.create(
-                user=self.remote_user, name="hi", privacy="public"
-            )
+        book_list = models.List.objects.create(
+            user=self.remote_user, name="hi", privacy="public"
+        )
         with patch("bookwyrm.lists_stream.add_list_task.delay") as mock:
             lists_stream.add_list_on_create_command(book_list.id)
         self.assertEqual(mock.call_count, 1)
         args = mock.call_args[0]
         self.assertEqual(args[0], book_list.id)
 
-    def test_remove_list_on_delete(self, _):
+    def test_remove_list_on_delete(self):
         """delete a list"""
-        with patch("bookwyrm.lists_stream.remove_list_task.delay"):
-            book_list = models.List.objects.create(
-                user=self.remote_user, name="hi", privacy="public"
-            )
+        book_list = models.List.objects.create(
+            user=self.remote_user, name="hi", privacy="public"
+        )
         with patch("bookwyrm.lists_stream.remove_list_task.delay") as mock:
             lists_stream.remove_list_on_delete(models.List, book_list)
         args = mock.call_args[0]
         self.assertEqual(args[0], book_list.id)
 
-    def test_populate_lists_on_account_create_command(self, _):
+    def test_populate_lists_on_account_create_command(self):
         """create streams for a user"""
         with patch("bookwyrm.lists_stream.populate_lists_task.delay") as mock:
             lists_stream.add_list_on_account_create_command(self.local_user.id)
@@ -65,8 +56,7 @@ class ListsStreamSignals(TestCase):
         args = mock.call_args[0]
         self.assertEqual(args[0], self.local_user.id)
 
-    @patch("bookwyrm.activitystreams.remove_user_statuses_task.delay")
-    def test_remove_lists_on_block(self, *_):
+    def test_remove_lists_on_block(self):
         """don't show lists from blocked users"""
         with patch("bookwyrm.lists_stream.remove_user_lists_task.delay") as mock:
             models.UserBlocks.objects.create(
@@ -78,16 +68,12 @@ class ListsStreamSignals(TestCase):
         self.assertEqual(args[0], self.local_user.id)
         self.assertEqual(args[1], self.remote_user.id)
 
-    @patch("bookwyrm.activitystreams.remove_user_statuses_task.delay")
-    @patch("bookwyrm.activitystreams.add_user_statuses_task.delay")
-    def test_add_lists_on_unblock(self, *_):
+    def test_add_lists_on_unblock(self):
         """re-add lists on unblock"""
-        with patch("bookwyrm.lists_stream.remove_user_lists_task.delay"):
-            block = models.UserBlocks.objects.create(
-                user_subject=self.local_user,
-                user_object=self.remote_user,
-            )
-
+        block = models.UserBlocks.objects.create(
+            user_subject=self.local_user,
+            user_object=self.remote_user,
+        )
         with patch("bookwyrm.lists_stream.add_user_lists_task.delay") as mock:
             block.delete()
 
@@ -95,20 +81,16 @@ class ListsStreamSignals(TestCase):
         self.assertEqual(args[0], self.local_user.id)
         self.assertEqual(args[1], self.remote_user.id)
 
-    @patch("bookwyrm.activitystreams.remove_user_statuses_task.delay")
-    @patch("bookwyrm.activitystreams.add_user_statuses_task.delay")
-    def test_add_lists_on_unblock_reciprocal_block(self, *_):
+    def test_add_lists_on_unblock_reciprocal_block(self):
         """dont' re-add lists on unblock if there's a block the other way"""
-        with patch("bookwyrm.lists_stream.remove_user_lists_task.delay"):
-            block = models.UserBlocks.objects.create(
-                user_subject=self.local_user,
-                user_object=self.remote_user,
-            )
-            block = models.UserBlocks.objects.create(
-                user_subject=self.remote_user,
-                user_object=self.local_user,
-            )
-
+        block = models.UserBlocks.objects.create(
+            user_subject=self.local_user,
+            user_object=self.remote_user,
+        )
+        block = models.UserBlocks.objects.create(
+            user_subject=self.remote_user,
+            user_object=self.local_user,
+        )
         with patch("bookwyrm.lists_stream.add_user_lists_task.delay") as mock:
             block.delete()
 

--- a/bookwyrm/tests/lists_stream/test_stream.py
+++ b/bookwyrm/tests/lists_stream/test_stream.py
@@ -7,53 +7,41 @@ from django.test import TestCase
 from bookwyrm import lists_stream, models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.remove_list_task.delay")
 class ListsStream(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """database setup"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.stream = lists_stream.ListsStream()
 
-    def test_lists_stream_ids(self, *_):
+    def test_lists_stream_ids(self):
         """the abstract base class for stream objects"""
         self.assertEqual(
             self.stream.stream_id(self.local_user),
             f"{self.local_user.id}-lists",
         )
 
-    def test_get_rank(self, *_):
+    def test_get_rank(self):
         """sort order for lists"""
         book_list = models.List.objects.create(
             user=self.remote_user, name="hi", privacy="public"
@@ -61,7 +49,7 @@ class ListsStream(TestCase):
         book_list.updated_date = datetime(2020, 1, 1, 0, 0, 0)
         self.assertEqual(self.stream.get_rank(book_list), 1577836800.0)
 
-    def test_add_user_lists(self, *_):
+    def test_add_user_lists(self):
         """add all of a user's lists"""
         book_list = models.List.objects.create(
             user=self.remote_user, name="hi", privacy="public"
@@ -75,7 +63,7 @@ class ListsStream(TestCase):
         self.assertEqual(args[0][0], book_list)
         self.assertEqual(args[1], f"{self.local_user.id}-lists")
 
-    def test_remove_user_lists(self, *_):
+    def test_remove_user_lists(self):
         """remove user's lists"""
         book_list = models.List.objects.create(
             user=self.remote_user, name="hi", privacy="public"
@@ -89,7 +77,7 @@ class ListsStream(TestCase):
         self.assertEqual(args[0][0], book_list)
         self.assertEqual(args[1], f"{self.local_user.id}-lists")
 
-    def test_get_audience(self, *_):
+    def test_get_audience(self):
         """get a list of users that should see a list"""
         book_list = models.List.objects.create(
             user=self.remote_user, name="hi", privacy="public"
@@ -100,7 +88,7 @@ class ListsStream(TestCase):
         self.assertTrue(self.local_user in users)
         self.assertTrue(self.another_user in users)
 
-    def test_get_audience_direct(self, *_):
+    def test_get_audience_direct(self):
         """get a list of users that should see a list"""
         book_list = models.List.objects.create(
             user=self.remote_user,
@@ -120,7 +108,7 @@ class ListsStream(TestCase):
         self.assertFalse(self.another_user in users)
         self.assertFalse(self.remote_user in users)
 
-    def test_get_audience_followers_remote_user(self, *_):
+    def test_get_audience_followers_remote_user(self):
         """get a list of users that should see a list"""
         book_list = models.List.objects.create(
             user=self.remote_user,
@@ -130,7 +118,7 @@ class ListsStream(TestCase):
         users = self.stream.get_audience(book_list)
         self.assertFalse(users.exists())
 
-    def test_get_audience_followers_self(self, *_):
+    def test_get_audience_followers_self(self):
         """get a list of users that should see a list"""
         book_list = models.List.objects.create(
             user=self.local_user,
@@ -142,7 +130,7 @@ class ListsStream(TestCase):
         self.assertFalse(self.another_user in users)
         self.assertFalse(self.remote_user in users)
 
-    def test_get_audience_followers_with_relationship(self, *_):
+    def test_get_audience_followers_with_relationship(self):
         """get a list of users that should see a list"""
         self.remote_user.followers.add(self.local_user)
         book_list = models.List.objects.create(
@@ -154,7 +142,7 @@ class ListsStream(TestCase):
         self.assertTrue(self.local_user in users)
         self.assertFalse(self.another_user in users)
 
-    def test_get_audience_followers_with_group(self, *_):
+    def test_get_audience_followers_with_group(self):
         """get a list of users that should see a list"""
         group = models.Group.objects.create(name="test group", user=self.remote_user)
         models.GroupMember.objects.create(

--- a/bookwyrm/tests/lists_stream/test_tasks.py
+++ b/bookwyrm/tests/lists_stream/test_tasks.py
@@ -5,49 +5,36 @@ from django.test import TestCase
 from bookwyrm import lists_stream, models
 
 
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.remove_user_statuses_task.delay")
-@patch("bookwyrm.activitystreams.add_user_statuses_task.delay")
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """database setup"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            cls.list = models.List.objects.create(
-                user=cls.local_user, name="hi", privacy="public"
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
+        cls.list = models.List.objects.create(
+            user=cls.local_user, name="hi", privacy="public"
+        )
 
-    def test_populate_lists_task(self, *_):
+    def test_populate_lists_task(self):
         """populate lists cache"""
         with patch("bookwyrm.lists_stream.ListsStream.populate_lists") as mock:
             lists_stream.populate_lists_task(self.local_user.id)
@@ -61,7 +48,7 @@ class Activitystreams(TestCase):
         args = mock.call_args[0]
         self.assertEqual(args[0], self.local_user)
 
-    def test_remove_list_task(self, *_):
+    def test_remove_list_task(self):
         """remove a list from all streams"""
         with patch(
             "bookwyrm.lists_stream.ListsStream.remove_object_from_stores"
@@ -71,7 +58,7 @@ class Activitystreams(TestCase):
         args = mock.call_args[0]
         self.assertEqual(args[0], self.list.id)
 
-    def test_add_list_task(self, *_):
+    def test_add_list_task(self):
         """add a list to all streams"""
         with patch("bookwyrm.lists_stream.ListsStream.add_list") as mock:
             lists_stream.add_list_task(self.list.id)
@@ -79,7 +66,7 @@ class Activitystreams(TestCase):
         args = mock.call_args[0]
         self.assertEqual(args[0], self.list)
 
-    def test_remove_user_lists_task(self, *_):
+    def test_remove_user_lists_task(self):
         """remove all lists by a user from another users' feeds"""
         with patch("bookwyrm.lists_stream.ListsStream.remove_user_lists") as mock:
             lists_stream.remove_user_lists_task(
@@ -99,7 +86,7 @@ class Activitystreams(TestCase):
         self.assertEqual(args[0], self.local_user)
         self.assertEqual(args[1], self.another_user)
 
-    def test_add_user_lists_task(self, *_):
+    def test_add_user_lists_task(self):
         """add a user's lists to another users feeds"""
         with patch("bookwyrm.lists_stream.ListsStream.add_user_lists") as mock:
             lists_stream.add_user_lists_task(self.local_user.id, self.another_user.id)

--- a/bookwyrm/tests/management/test_populate_lists_streams.py
+++ b/bookwyrm/tests/management/test_populate_lists_streams.py
@@ -7,51 +7,42 @@ from bookwyrm import models
 from bookwyrm.management.commands.populate_lists_streams import populate_lists_streams
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """we need some stuff"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-            models.User.objects.create_user(
-                "gerbil",
-                "gerbil@nutria.nutria",
-                "password",
-                local=True,
-                localname="gerbil",
-                is_active=False,
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        models.User.objects.create_user(
+            "gerbil",
+            "gerbil@nutria.nutria",
+            "password",
+            local=True,
+            localname="gerbil",
+            is_active=False,
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.book = models.Edition.objects.create(title="test book")
 
-    def test_populate_streams(self, *_):
+    def test_populate_streams(self):
         """make sure the function on the redis manager gets called"""
         with patch("bookwyrm.lists_stream.populate_lists_task.delay") as list_mock:
             populate_lists_streams()

--- a/bookwyrm/tests/management/test_populate_streams.py
+++ b/bookwyrm/tests/management/test_populate_streams.py
@@ -7,55 +7,46 @@ from bookwyrm import models
 from bookwyrm.management.commands.populate_streams import populate_streams
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class Activitystreams(TestCase):
     """using redis to build activity streams"""
 
     @classmethod
     def setUpTestData(cls):
         """we need some stuff"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-            models.User.objects.create_user(
-                "gerbil",
-                "gerbil@gerbil.gerbil",
-                "password",
-                local=True,
-                localname="gerbil",
-                is_active=False,
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        models.User.objects.create_user(
+            "gerbil",
+            "gerbil@gerbil.gerbil",
+            "password",
+            local=True,
+            localname="gerbil",
+            is_active=False,
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.book = models.Edition.objects.create(title="test book")
 
-    def test_populate_streams(self, _):
+    def test_populate_streams(self):
         """make sure the function on the redis manager gets called"""
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            models.Comment.objects.create(
-                user=self.local_user, content="hi", book=self.book
-            )
-
+        models.Comment.objects.create(
+            user=self.local_user, content="hi", book=self.book
+        )
         with (
             patch("bookwyrm.activitystreams.populate_stream_task.delay") as redis_mock,
             patch("bookwyrm.lists_stream.populate_lists_task.delay") as list_mock,

--- a/bookwyrm/tests/models/test_activitypub_mixin.py
+++ b/bookwyrm/tests/models/test_activitypub_mixin.py
@@ -21,34 +21,26 @@ from bookwyrm.models.activitypub_mixin import (
 from bookwyrm.settings import PAGE_LENGTH
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class ActivitypubMixins(TestCase):
     """functionality shared across models"""
 
     @classmethod
     def setUpTestData(cls):
         """shared data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.com", "mouseword", local=True, localname="mouse"
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.com", "mouseword", local=True, localname="mouse"
+        )
         cls.local_user.remote_id = "http://example.com/a/b"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
     def setUp(self):
         """test data"""
@@ -61,7 +53,7 @@ class ActivitypubMixins(TestCase):
             "published": "2020-12-04T17:52:22.623807+00:00",
         }
 
-    def test_to_activity(self, *_):
+    def test_to_activity(self):
         """model to ActivityPub json"""
 
         @dataclass(init=False)
@@ -82,7 +74,7 @@ class ActivitypubMixins(TestCase):
         self.assertEqual(activity["id"], "https://www.example.com/test")
         self.assertEqual(activity["type"], "Test")
 
-    def test_find_existing_by_remote_id(self, *_):
+    def test_find_existing_by_remote_id(self):
         """attempt to match a remote id to an object in the db"""
         # uses a different remote id scheme
         # this isn't really part of this test directly but it's helpful to state
@@ -114,7 +106,7 @@ class ActivitypubMixins(TestCase):
         # test subclass match
         result = models.Status.find_existing_by_remote_id("https://comment.net")
 
-    def test_find_existing(self, *_):
+    def test_find_existing(self):
         """match a blob of data to a model"""
         book = models.Edition.objects.create(
             title="Test edition",
@@ -124,14 +116,14 @@ class ActivitypubMixins(TestCase):
         result = models.Edition.find_existing({"openlibraryKey": "OL1234"})
         self.assertEqual(result, book)
 
-    def test_find_existing_with_id(self, *_):
+    def test_find_existing_with_id(self):
         """make sure that an "id" field won't produce a match"""
         book = models.Edition.objects.create(title="Test edition")
 
         result = models.Edition.find_existing({"id": book.id})
         self.assertIsNone(result)
 
-    def test_find_existing_with_id_and_match(self, *_):
+    def test_find_existing_with_id_and_match(self):
         """make sure that an "id" field won't produce a match"""
         book = models.Edition.objects.create(title="Test edition")
         matching_book = models.Edition.objects.create(
@@ -143,7 +135,7 @@ class ActivitypubMixins(TestCase):
         )
         self.assertEqual(result, matching_book)
 
-    def test_get_recipients_public_object(self, *_):
+    def test_get_recipients_public_object(self):
         """determines the recipients for an object's broadcast"""
         MockSelf = namedtuple("Self", ("privacy"))
         mock_self = MockSelf("public")
@@ -151,7 +143,7 @@ class ActivitypubMixins(TestCase):
         self.assertEqual(len(recipients), 1)
         self.assertEqual(recipients[0], self.remote_user.inbox)
 
-    def test_get_recipients_public_user_object_no_followers(self, *_):
+    def test_get_recipients_public_user_object_no_followers(self):
         """determines the recipients for a user's object broadcast"""
         MockSelf = namedtuple("Self", ("privacy", "user"))
         mock_self = MockSelf("public", self.local_user)
@@ -159,7 +151,7 @@ class ActivitypubMixins(TestCase):
         recipients = ActivitypubMixin.get_recipients(mock_self)
         self.assertEqual(len(recipients), 0)
 
-    def test_get_recipients_public_user_object(self, *_):
+    def test_get_recipients_public_user_object(self):
         """determines the recipients for a user's object broadcast"""
         MockSelf = namedtuple("Self", ("privacy", "user"))
         mock_self = MockSelf("public", self.local_user)
@@ -169,21 +161,20 @@ class ActivitypubMixins(TestCase):
         self.assertEqual(len(recipients), 1)
         self.assertEqual(recipients[0], self.remote_user.inbox)
 
-    def test_get_recipients_public_user_object_with_mention(self, *_):
+    def test_get_recipients_public_user_object_with_mention(self):
         """determines the recipients for a user's object broadcast"""
         MockSelf = namedtuple("Self", ("privacy", "user"))
         mock_self = MockSelf("public", self.local_user)
         self.local_user.followers.add(self.remote_user)
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            another_remote_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.com",
-                "nutriaword",
-                local=False,
-                remote_id="https://example.com/users/nutria",
-                inbox="https://example.com/users/nutria/inbox",
-                outbox="https://example.com/users/nutria/outbox",
-            )
+        another_remote_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.com",
+            "nutriaword",
+            local=False,
+            remote_id="https://example.com/users/nutria",
+            inbox="https://example.com/users/nutria/inbox",
+            outbox="https://example.com/users/nutria/outbox",
+        )
         MockSelf = namedtuple("Self", ("privacy", "user", "recipients"))
         mock_self = MockSelf("public", self.local_user, [another_remote_user])
 
@@ -192,21 +183,20 @@ class ActivitypubMixins(TestCase):
         self.assertTrue(another_remote_user.inbox in recipients)
         self.assertTrue(self.remote_user.inbox in recipients)
 
-    def test_get_recipients_direct(self, *_):
+    def test_get_recipients_direct(self):
         """determines the recipients for a user's object broadcast"""
         MockSelf = namedtuple("Self", ("privacy", "user"))
         mock_self = MockSelf("public", self.local_user)
         self.local_user.followers.add(self.remote_user)
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            another_remote_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.com",
-                "nutriaword",
-                local=False,
-                remote_id="https://example.com/users/nutria",
-                inbox="https://example.com/users/nutria/inbox",
-                outbox="https://example.com/users/nutria/outbox",
-            )
+        another_remote_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.com",
+            "nutriaword",
+            local=False,
+            remote_id="https://example.com/users/nutria",
+            inbox="https://example.com/users/nutria/inbox",
+            outbox="https://example.com/users/nutria/outbox",
+        )
         MockSelf = namedtuple("Self", ("privacy", "user", "recipients"))
         mock_self = MockSelf("direct", self.local_user, [another_remote_user])
 
@@ -214,21 +204,20 @@ class ActivitypubMixins(TestCase):
         self.assertEqual(len(recipients), 1)
         self.assertEqual(recipients[0], another_remote_user.inbox)
 
-    def test_get_recipients_combine_inboxes(self, *_):
+    def test_get_recipients_combine_inboxes(self):
         """should combine users with the same shared_inbox"""
         self.remote_user.shared_inbox = "http://example.com/inbox"
         self.remote_user.save(broadcast=False, update_fields=["shared_inbox"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            another_remote_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.com",
-                "nutriaword",
-                local=False,
-                remote_id="https://example.com/users/nutria",
-                inbox="https://example.com/users/nutria/inbox",
-                shared_inbox="http://example.com/inbox",
-                outbox="https://example.com/users/nutria/outbox",
-            )
+        another_remote_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.com",
+            "nutriaword",
+            local=False,
+            remote_id="https://example.com/users/nutria",
+            inbox="https://example.com/users/nutria/inbox",
+            shared_inbox="http://example.com/inbox",
+            outbox="https://example.com/users/nutria/outbox",
+        )
         MockSelf = namedtuple("Self", ("privacy", "user", "recipients"))
         self.local_user.followers.add(self.remote_user)
         self.local_user.followers.add(another_remote_user)
@@ -242,19 +231,18 @@ class ActivitypubMixins(TestCase):
         recipients = ActivitypubMixin.get_recipients(mock_self)
         self.assertCountEqual(recipients, ["http://example.com/inbox"])
 
-    def test_get_recipients_software(self, *_):
+    def test_get_recipients_software(self):
         """should differentiate between bookwyrm and other remote users"""
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            another_remote_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.com",
-                "nutriaword",
-                local=False,
-                remote_id="https://example.com/users/nutria",
-                inbox="https://example.com/users/nutria/inbox",
-                outbox="https://example.com/users/nutria/outbox",
-                bookwyrm_user=False,
-            )
+        another_remote_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.com",
+            "nutriaword",
+            local=False,
+            remote_id="https://example.com/users/nutria",
+            inbox="https://example.com/users/nutria/inbox",
+            outbox="https://example.com/users/nutria/outbox",
+            bookwyrm_user=False,
+        )
         MockSelf = namedtuple("Self", ("privacy", "user"))
         mock_self = MockSelf("public", self.local_user)
         self.local_user.followers.add(self.remote_user)
@@ -272,7 +260,7 @@ class ActivitypubMixins(TestCase):
         self.assertEqual(recipients[0], another_remote_user.inbox)
 
     # ObjectMixin
-    def test_object_save_create(self, *_):
+    def test_object_save_create(self):
         """should save uneventfully when broadcast is disabled"""
 
         class Success(Exception):
@@ -301,7 +289,7 @@ class ActivitypubMixins(TestCase):
         ObjectModel(user=self.local_user).save(broadcast=False)
         ObjectModel(user=None).save()
 
-    def test_object_save_update(self, *_):
+    def test_object_save_update(self):
         """should save uneventfully when broadcast is disabled"""
 
         class Success(Exception):
@@ -327,7 +315,7 @@ class ActivitypubMixins(TestCase):
         with self.assertRaises(Success):
             UpdateObjectModel(id=1, last_edited_by=self.local_user).save()
 
-    def test_object_save_delete(self, *_):
+    def test_object_save_delete(self):
         """should create delete activities when objects are deleted by flag"""
 
         class ActivitySuccess(Exception):
@@ -349,7 +337,7 @@ class ActivitypubMixins(TestCase):
         with self.assertRaises(ActivitySuccess):
             DeletableObjectModel(id=1, user=self.local_user, deleted=True).save()
 
-    def test_to_delete_activity(self, *_):
+    def test_to_delete_activity(self):
         """wrapper for Delete activity"""
         MockSelf = namedtuple("Self", ("remote_id", "to_activity"))
         mock_self = MockSelf(
@@ -364,7 +352,7 @@ class ActivitypubMixins(TestCase):
             activity["cc"], ["https://www.w3.org/ns/activitystreams#Public"]
         )
 
-    def test_to_update_activity(self, *_):
+    def test_to_update_activity(self):
         """ditto above but for Update"""
         MockSelf = namedtuple("Self", ("remote_id", "to_activity"))
         mock_self = MockSelf(
@@ -381,7 +369,7 @@ class ActivitypubMixins(TestCase):
         )
         self.assertIsInstance(activity["object"], dict)
 
-    def test_to_undo_activity(self, *_):
+    def test_to_undo_activity(self):
         """and again, for Undo"""
         MockSelf = namedtuple("Self", ("remote_id", "to_activity", "user"))
         mock_self = MockSelf(
@@ -395,7 +383,7 @@ class ActivitypubMixins(TestCase):
         self.assertEqual(activity["type"], "Undo")
         self.assertIsInstance(activity["object"], dict)
 
-    def test_to_ordered_collection_page(self, *_):
+    def test_to_ordered_collection_page(self):
         """make sure the paged results of an ordered collection work"""
         self.assertEqual(PAGE_LENGTH, 15)
         models.Status.objects.bulk_create(
@@ -422,7 +410,7 @@ class ActivitypubMixins(TestCase):
         self.assertEqual(page_2.orderedItems[0]["content"], "<p>test status 14</p>")
         self.assertEqual(page_2.orderedItems[-1]["content"], "<p>test status 0</p>")
 
-    def test_to_ordered_collection(self, *_):
+    def test_to_ordered_collection(self):
         """convert a queryset into an ordered collection object"""
         self.assertEqual(PAGE_LENGTH, 15)
         models.Status.objects.bulk_create(
@@ -451,7 +439,7 @@ class ActivitypubMixins(TestCase):
         self.assertEqual(page_2.orderedItems[0]["content"], "<p>test status 14</p>")
         self.assertEqual(page_2.orderedItems[-1]["content"], "<p>test status 0</p>")
 
-    def test_broadcast_task(self, *_):
+    def test_broadcast_task(self):
         """Should be calling asyncio"""
         recipients = [
             "https://instance.example/user/inbox",

--- a/bookwyrm/tests/models/test_automod.py
+++ b/bookwyrm/tests/models/test_automod.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 from django.test.client import RequestFactory
 
@@ -9,40 +7,32 @@ from bookwyrm import models
 from bookwyrm.models.antispam import automod_task
 
 
-@patch("bookwyrm.models.Status.broadcast")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class AutomodModel(TestCase):
     """every response to a get request, html or json"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-                is_superuser=True,
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+            is_superuser=True,
+        )
 
     def setUp(self):
         self.factory = RequestFactory()
 
-    def test_automod_task_no_rules(self, *_):
+    def test_automod_task_no_rules(self):
         """nothing to see here"""
         self.assertFalse(models.Report.objects.exists())
         automod_task()
         self.assertFalse(models.Report.objects.exists())
         self.assertFalse(models.Notification.objects.exists())
 
-    def test_automod_task_user(self, *_):
+    def test_automod_task_user(self):
         """scan activity"""
         self.assertFalse(models.Report.objects.exists())
         models.AutoMod.objects.create(
@@ -62,7 +52,7 @@ class AutomodModel(TestCase):
         self.assertEqual(reports.first().user, self.local_user)
         self.assertEqual(models.Notification.objects.count(), 1)
 
-    def test_automod_status(self, *_):
+    def test_automod_status(self):
         """scan activity"""
         self.assertFalse(models.Report.objects.exists())
         models.AutoMod.objects.create(

--- a/bookwyrm/tests/models/test_base_model.py
+++ b/bookwyrm/tests/models/test_base_model.py
@@ -1,6 +1,5 @@
 """testing models"""
 
-from unittest.mock import patch
 from django.http import Http404
 from django.test import TestCase
 
@@ -15,24 +14,18 @@ class BaseModel(TestCase):
     @classmethod
     def setUpTestData(cls):
         """shared data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.com", "mouseword", local=True, localname="mouse"
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.com", "mouseword", local=True, localname="mouse"
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
     def setUp(self):
         class BookWyrmTestModel(base_model.BookWyrmModel):
@@ -67,8 +60,7 @@ class BaseModel(TestCase):
         base_model.set_remote_id(None, instance, False)
         self.assertIsNone(instance.remote_id)
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_object_visible_to_user(self, _):
+    def test_object_visible_to_user(self):
         """does a user have permission to view an object"""
         obj = models.Status.objects.create(
             content="hi", user=self.remote_user, privacy="public"
@@ -98,8 +90,7 @@ class BaseModel(TestCase):
         obj.mention_users.add(self.local_user)
         self.assertIsNone(obj.raise_visible_to_user(self.local_user))
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_object_visible_to_user_follower(self, _):
+    def test_object_visible_to_user_follower(self):
         """what you can see if you follow a user"""
         self.remote_user.followers.add(self.local_user)
         obj = models.Status.objects.create(
@@ -119,8 +110,7 @@ class BaseModel(TestCase):
         obj.mention_users.add(self.local_user)
         self.assertIsNone(obj.raise_visible_to_user(self.local_user))
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_object_visible_to_user_blocked(self, _):
+    def test_object_visible_to_user_blocked(self):
         """you can't see it if they block you"""
         self.remote_user.blocks.add(self.local_user)
         obj = models.Status.objects.create(

--- a/bookwyrm/tests/models/test_bookwyrm_export_job.py
+++ b/bookwyrm/tests/models/test_bookwyrm_export_job.py
@@ -4,7 +4,6 @@ import datetime
 import json
 import pathlib
 
-from unittest.mock import patch
 
 from django.utils import timezone
 from django.test import TestCase
@@ -17,176 +16,164 @@ class BookwyrmExportJob(TestCase):
     """testing user export functions"""
 
     @classmethod
-    def setUpTestData(self):
+    def setUpTestData(cls):
         """lots of stuff to set up for a user export"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_book_statuses_task"),
-        ):
-            self.local_user = models.User.objects.create_user(
-                "mouse",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-                name="Mouse",
-                summary="I'm a real bookmouse",
-                manually_approves_followers=False,
-                hide_follows=False,
-                show_goal=False,
-                show_suggested_users=False,
-                discoverable=True,
-                preferred_timezone="America/Los Angeles",
-                default_post_privacy="followers",
-            )
-            avatar_path = pathlib.Path(__file__).parent.joinpath(
-                "../../static/images/default_avi.jpg"
-            )
-            with open(avatar_path, "rb") as avatar_file:
-                self.local_user.avatar.save("mouse-avatar.jpg", avatar_file)
+        cls.local_user = models.User.objects.create_user(
+            "mouse",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+            name="Mouse",
+            summary="I'm a real bookmouse",
+            manually_approves_followers=False,
+            hide_follows=False,
+            show_goal=False,
+            show_suggested_users=False,
+            discoverable=True,
+            preferred_timezone="America/Los Angeles",
+            default_post_privacy="followers",
+        )
+        avatar_path = pathlib.Path(__file__).parent.joinpath(
+            "../../static/images/default_avi.jpg"
+        )
+        with open(avatar_path, "rb") as avatar_file:
+            cls.local_user.avatar.save("mouse-avatar.jpg", avatar_file)
 
-            self.rat_user = models.User.objects.create_user(
-                "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
-            )
+        cls.rat_user = models.User.objects.create_user(
+            "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
+        )
 
-            self.badger_user = models.User.objects.create_user(
-                "badger",
-                "badger@badger.badger",
-                "badgerword",
-                local=True,
-                localname="badger",
-            )
+        cls.badger_user = models.User.objects.create_user(
+            "badger",
+            "badger@badger.badger",
+            "badgerword",
+            local=True,
+            localname="badger",
+        )
 
-            models.AnnualGoal.objects.create(
-                user=self.local_user,
-                year=timezone.now().year,
-                goal=128937123,
-                privacy="followers",
-            )
+        models.AnnualGoal.objects.create(
+            user=cls.local_user,
+            year=timezone.now().year,
+            goal=128937123,
+            privacy="followers",
+        )
 
-            self.list = models.List.objects.create(
-                name="My excellent list",
-                user=self.local_user,
-                remote_id="https://local.lists/1111",
-            )
+        cls.list = models.List.objects.create(
+            name="My excellent list",
+            user=cls.local_user,
+            remote_id="https://local.lists/1111",
+        )
 
-            self.saved_list = models.List.objects.create(
-                name="My cool list",
-                user=self.rat_user,
-                remote_id="https://local.lists/9999",
-            )
+        cls.saved_list = models.List.objects.create(
+            name="My cool list",
+            user=cls.rat_user,
+            remote_id="https://local.lists/9999",
+        )
 
-            self.local_user.saved_lists.add(self.saved_list)
-            self.local_user.blocks.add(self.badger_user)
-            self.rat_user.followers.add(self.local_user)
+        cls.local_user.saved_lists.add(cls.saved_list)
+        cls.local_user.blocks.add(cls.badger_user)
+        cls.rat_user.followers.add(cls.local_user)
 
-            # book, edition, author
-            self.author = models.Author.objects.create(name="Sam Zhu")
-            self.work = models.Work.objects.create(
-                title="Example Work", remote_id="https://example.com/book/1"
-            )
-            self.edition = models.Edition.objects.create(
-                title="Example Edition", parent_work=self.work
-            )
-            self.second_work = models.Work.objects.create(
-                title="Another Example Work", remote_id="https://example.com/book/2"
-            )
-            self.another_edition = models.Edition.objects.create(
-                title="Another Edition", parent_work=self.second_work
-            )
+        # book, edition, author
+        cls.author = models.Author.objects.create(name="Sam Zhu")
+        cls.work = models.Work.objects.create(
+            title="Example Work", remote_id="https://example.com/book/1"
+        )
+        cls.edition = models.Edition.objects.create(
+            title="Example Edition", parent_work=cls.work
+        )
+        cls.second_work = models.Work.objects.create(
+            title="Another Example Work", remote_id="https://example.com/book/2"
+        )
+        cls.another_edition = models.Edition.objects.create(
+            title="Another Edition", parent_work=cls.second_work
+        )
 
-            # edition cover
-            cover_path = pathlib.Path(__file__).parent.joinpath(
-                "../../static/images/default_avi.jpg"
-            )
-            with open(cover_path, "rb") as cover_file:
-                self.edition.cover.save("tèst.jpg", cover_file)
+        # edition cover
+        cover_path = pathlib.Path(__file__).parent.joinpath(
+            "../../static/images/default_avi.jpg"
+        )
+        with open(cover_path, "rb") as cover_file:
+            cls.edition.cover.save("tèst.jpg", cover_file)
 
-            self.edition.authors.add(self.author)
+        cls.edition.authors.add(cls.author)
 
-            # readthrough
-            self.readthrough_start = timezone.now()
-            finish = self.readthrough_start + datetime.timedelta(days=1)
-            models.ReadThrough.objects.create(
-                user=self.local_user,
-                book=self.edition,
-                start_date=self.readthrough_start,
-                finish_date=finish,
-            )
-            models.ReadThrough.objects.create(
-                user=self.local_user,
-                book=self.another_edition,
-                start_date=self.readthrough_start,
-                finish_date=finish,
-            )
+        # readthrough
+        cls.readthrough_start = timezone.now()
+        finish = cls.readthrough_start + datetime.timedelta(days=1)
+        models.ReadThrough.objects.create(
+            user=cls.local_user,
+            book=cls.edition,
+            start_date=cls.readthrough_start,
+            finish_date=finish,
+        )
+        models.ReadThrough.objects.create(
+            user=cls.local_user,
+            book=cls.another_edition,
+            start_date=cls.readthrough_start,
+            finish_date=finish,
+        )
 
-            # shelve
-            read_shelf = models.Shelf.objects.get(
-                user=self.local_user, identifier="read"
-            )
-            models.ShelfBook.objects.create(
-                book=self.edition, shelf=read_shelf, user=self.local_user
-            )
+        # shelve
+        read_shelf = models.Shelf.objects.get(user=cls.local_user, identifier="read")
+        models.ShelfBook.objects.create(
+            book=cls.edition, shelf=read_shelf, user=cls.local_user
+        )
 
-            # add to list
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.edition,
-                approved=True,
-                order=1,
-            )
+        # add to list
+        models.ListItem.objects.create(
+            book_list=cls.list,
+            user=cls.local_user,
+            book=cls.edition,
+            approved=True,
+            order=1,
+        )
 
-            # review
-            models.Review.objects.create(
-                content="awesome",
-                name="my review",
-                rating=5,
-                user=self.local_user,
-                book=self.edition,
-            )
-            # comment
-            models.Comment.objects.create(
-                content="ok so far",
-                user=self.local_user,
-                book=self.edition,
-                progress=15,
-            )
-            # deleted comment
-            models.Comment.objects.create(
-                content="so far",
-                user=self.local_user,
-                book=self.edition,
-                progress=5,
-                deleted=True,
-            )
-            # quote
-            models.Quotation.objects.create(
-                content="check this out",
-                quote="A rose by any other name",
-                user=self.local_user,
-                book=self.edition,
-            )
-            # deleted quote
-            models.Quotation.objects.create(
-                content="check this out",
-                quote="A rose by any other name",
-                user=self.local_user,
-                book=self.edition,
-                deleted=True,
-            )
+        # review
+        models.Review.objects.create(
+            content="awesome",
+            name="my review",
+            rating=5,
+            user=cls.local_user,
+            book=cls.edition,
+        )
+        # comment
+        models.Comment.objects.create(
+            content="ok so far",
+            user=cls.local_user,
+            book=cls.edition,
+            progress=15,
+        )
+        # deleted comment
+        models.Comment.objects.create(
+            content="so far",
+            user=cls.local_user,
+            book=cls.edition,
+            progress=5,
+            deleted=True,
+        )
+        # quote
+        models.Quotation.objects.create(
+            content="check this out",
+            quote="A rose by any other name",
+            user=cls.local_user,
+            book=cls.edition,
+        )
+        # deleted quote
+        models.Quotation.objects.create(
+            content="check this out",
+            quote="A rose by any other name",
+            user=cls.local_user,
+            book=cls.edition,
+            deleted=True,
+        )
 
-            self.job = models.BookwyrmExportJob.objects.create(user=self.local_user)
+        cls.job = models.BookwyrmExportJob.objects.create(user=cls.local_user)
 
-            # run the first stage of the export
-            with patch("bookwyrm.models.bookwyrm_export_job.create_archive_task.delay"):
-                models.bookwyrm_export_job.create_export_json_task(job_id=self.job.id)
-            self.job.refresh_from_db()
+        # run the first stage of the export
+        models.bookwyrm_export_job.create_export_json_task(job_id=cls.job.id)
+        cls.job.refresh_from_db()
 
     def test_add_book_to_user_export_job(self):
         """does AddBookToUserExportJob ...add the book to the export?"""

--- a/bookwyrm/tests/models/test_bookwyrm_import_job.py
+++ b/bookwyrm/tests/models/test_bookwyrm_import_job.py
@@ -19,119 +19,99 @@ class BookwyrmImport(TestCase):
     """testing user import functions"""
 
     @classmethod
-    def setUpTestData(self):
+    def setUpTestData(cls):
         """setting stuff up"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
-        ):
-            self.local_user = models.User.objects.create_user(
-                "mouse",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-                name="Mouse",
-                summary="I'm a real bookmouse",
-                manually_approves_followers=False,
-                hide_follows=False,
-                show_goal=True,
-                show_suggested_users=True,
-                discoverable=True,
-                preferred_timezone="America/Los Angeles",
-                default_post_privacy="public",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+            name="Mouse",
+            summary="I'm a real bookmouse",
+            manually_approves_followers=False,
+            hide_follows=False,
+            show_goal=True,
+            show_suggested_users=True,
+            discoverable=True,
+            preferred_timezone="America/Los Angeles",
+            default_post_privacy="public",
+        )
 
-            self.rat_user = models.User.objects.create_user(
-                "rat", "rat@rat.rat", "password", local=True, localname="rat"
-            )
+        cls.rat_user = models.User.objects.create_user(
+            "rat", "rat@rat.rat", "password", local=True, localname="rat"
+        )
 
-            self.badger_user = models.User.objects.create_user(
-                "badger",
-                "badger@badger.badger",
-                "password",
-                local=False,
-                localname="badger",
-                remote_id="badger@remote.remote",
-            )
+        cls.badger_user = models.User.objects.create_user(
+            "badger",
+            "badger@badger.badger",
+            "password",
+            local=False,
+            localname="badger",
+            remote_id="badger@remote.remote",
+        )
 
-            self.work = models.Work.objects.create(title="Sand Talk")
+        cls.work = models.Work.objects.create(title="Sand Talk")
 
-            self.book = models.Edition.objects.create(
-                title="Sand Talk",
-                remote_id="https://example.com/book/1234",
-                openlibrary_key="OL28216445M",
-                inventaire_id="isbn:9780062975645",
-                isbn_13="9780062975645",
-                parent_work=self.work,
-            )
+        cls.book = models.Edition.objects.create(
+            title="Sand Talk",
+            remote_id="https://example.com/book/1234",
+            openlibrary_key="OL28216445M",
+            inventaire_id="isbn:9780062975645",
+            isbn_13="9780062975645",
+            parent_work=cls.work,
+        )
 
-        self.json_file = pathlib.Path(__file__).parent.joinpath(
+        cls.json_file = pathlib.Path(__file__).parent.joinpath(
             "../data/user_import.json"
         )
 
-        with open(self.json_file, "r", encoding="utf-8") as jsonfile:
-            self.json_data = json.loads(jsonfile.read())
+        with open(cls.json_file, "r", encoding="utf-8") as jsonfile:
+            cls.json_data = json.loads(jsonfile.read())
 
-        self.archive_file_path = os.path.relpath(
+        cls.archive_file_path = os.path.relpath(
             pathlib.Path(__file__).parent.joinpath(
                 "../data/bookwyrm_account_export.tar.gz"
             )
         )
 
-        self.job = bookwyrm_import_job.BookwyrmImportJob.objects.create(
-            user=self.local_user, required=[]
+        cls.job = bookwyrm_import_job.BookwyrmImportJob.objects.create(
+            user=cls.local_user, required=[]
         )
 
     def test_update_user_profile(self):
         """Test update the user's profile from import data"""
-
         with (
-            patch("bookwyrm.suggested_users.remove_user_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
+            open(self.archive_file_path, "rb") as fileobj,
+            BookwyrmTarFile.open(mode="r:gz", fileobj=fileobj) as tarfile,
         ):
-            with (
-                open(self.archive_file_path, "rb") as fileobj,
-                BookwyrmTarFile.open(mode="r:gz", fileobj=fileobj) as tarfile,
-            ):
-                models.bookwyrm_import_job.update_user_profile(
-                    self.local_user, tarfile, self.json_data
-                )
-
-            self.local_user.refresh_from_db()
-
-            self.assertEqual(
-                self.local_user.username, "mouse"
-            )  # username should not change
-            self.assertEqual(self.local_user.name, "Rat")
-            self.assertEqual(
-                self.local_user.summary,
-                "I love to make soup in Paris and eat pizza in New York",
+            models.bookwyrm_import_job.update_user_profile(
+                self.local_user, tarfile, self.json_data
             )
+
+        self.local_user.refresh_from_db()
+
+        self.assertEqual(
+            self.local_user.username, "mouse"
+        )  # username should not change
+        self.assertEqual(self.local_user.name, "Rat")
+        self.assertEqual(
+            self.local_user.summary,
+            "I love to make soup in Paris and eat pizza in New York",
+        )
 
     def test_update_user_settings(self):
         """Test updating the user's settings from import data"""
+        models.bookwyrm_import_job.update_user_settings(self.local_user, self.json_data)
+        self.local_user.refresh_from_db()
 
-        with (
-            patch("bookwyrm.suggested_users.remove_user_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
-        ):
-            models.bookwyrm_import_job.update_user_settings(
-                self.local_user, self.json_data
-            )
-            self.local_user.refresh_from_db()
-
-            self.assertEqual(self.local_user.manually_approves_followers, True)
-            self.assertEqual(self.local_user.hide_follows, True)
-            self.assertEqual(self.local_user.show_goal, False)
-            self.assertEqual(self.local_user.show_suggested_users, False)
-            self.assertEqual(self.local_user.discoverable, False)
-            self.assertEqual(self.local_user.preferred_timezone, "Australia/Adelaide")
-            self.assertEqual(self.local_user.default_post_privacy, "followers")
+        self.assertEqual(self.local_user.manually_approves_followers, True)
+        self.assertEqual(self.local_user.hide_follows, True)
+        self.assertEqual(self.local_user.show_goal, False)
+        self.assertEqual(self.local_user.show_suggested_users, False)
+        self.assertEqual(self.local_user.discoverable, False)
+        self.assertEqual(self.local_user.preferred_timezone, "Australia/Adelaide")
+        self.assertEqual(self.local_user.default_post_privacy, "followers")
 
     def test_update_goals(self):
         """Test update the user's goals from import data"""
@@ -145,8 +125,7 @@ class BookwyrmImport(TestCase):
 
         goals = [{"goal": 12, "year": 2023, "privacy": "followers"}]
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.bookwyrm_import_job.update_goals(self.local_user, goals)
+        models.bookwyrm_import_job.update_goals(self.local_user, goals)
 
         self.local_user.refresh_from_db()
         goal = models.AnnualGoal.objects.get()
@@ -156,16 +135,11 @@ class BookwyrmImport(TestCase):
 
     def test_upsert_saved_lists_existing(self):
         """Test upserting an existing saved list"""
-
-        with (
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-        ):
-            book_list = models.List.objects.create(
-                name="My cool list",
-                user=self.rat_user,
-                remote_id="https://local.lists/9999",
-            )
+        book_list = models.List.objects.create(
+            name="My cool list",
+            user=self.rat_user,
+            remote_id="https://local.lists/9999",
+        )
 
         self.assertFalse(self.local_user.saved_lists.filter(id=book_list.id).exists())
 
@@ -184,16 +158,11 @@ class BookwyrmImport(TestCase):
 
     def test_upsert_saved_lists_not_existing(self):
         """Test upserting a new saved list"""
-
-        with (
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-        ):
-            book_list = models.List.objects.create(
-                name="My cool list",
-                user=self.rat_user,
-                remote_id="https://local.lists/9999",
-            )
+        book_list = models.List.objects.create(
+            name="My cool list",
+            user=self.rat_user,
+            remote_id="https://local.lists/9999",
+        )
 
         self.assertFalse(self.local_user.saved_lists.filter(id=book_list.id).exists())
 
@@ -219,11 +188,8 @@ class BookwyrmImport(TestCase):
 
         self.assertFalse(before_follow)
 
-        with (
-            patch("bookwyrm.activitystreams.add_user_statuses_task.delay"),
-            patch("bookwyrm.lists_stream.add_user_lists_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitypub.resolve_remote_id", return_value=self.rat_user),
+        with patch(
+            "bookwyrm.activitypub.resolve_remote_id", return_value=self.rat_user
         ):
             bookwyrm_import_job.import_user_relationship_task(child_id=task.id)
 
@@ -406,10 +372,6 @@ class BookwyrmImport(TestCase):
         self.assertFalse(blocked_before)
 
         with (
-            patch("bookwyrm.suggested_users.remove_suggestion_task.delay"),
-            patch("bookwyrm.activitystreams.remove_user_statuses_task.delay"),
-            patch("bookwyrm.lists_stream.remove_user_lists_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
             patch(
                 "bookwyrm.activitypub.resolve_remote_id", return_value=self.badger_user
             ),
@@ -621,17 +583,13 @@ class BookwyrmImport(TestCase):
             title="Another Book", remote_id="https://example.com/book/9876"
         )
 
-        with (
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-        ):
-            book_list = models.List.objects.create(
-                name="my list of books", user=self.local_user
-            )
+        book_list = models.List.objects.create(
+            name="my list of books", user=self.local_user
+        )
 
-            models.ListItem.objects.create(
-                book=self.book, book_list=book_list, user=self.local_user, order=1
-            )
+        models.ListItem.objects.create(
+            book=self.book, book_list=book_list, user=self.local_user, order=1
+        )
 
         self.assertTrue(models.List.objects.filter(id=book_list.id).exists())
         self.assertEqual(models.List.objects.filter(user=self.local_user).count(), 1)
@@ -642,15 +600,11 @@ class BookwyrmImport(TestCase):
             1,
         )
 
-        with (
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-        ):
-            bookwyrm_import_job.upsert_lists(
-                self.local_user,
-                other_book.id,
-                self.json_data["books"][0]["lists"],
-            )
+        bookwyrm_import_job.upsert_lists(
+            self.local_user,
+            other_book.id,
+            self.json_data["books"][0]["lists"],
+        )
 
         self.assertEqual(models.List.objects.filter(user=self.local_user).count(), 1)
         self.assertEqual(models.List.objects.filter(user=self.local_user).count(), 1)
@@ -668,15 +622,11 @@ class BookwyrmImport(TestCase):
         self.assertEqual(models.List.objects.filter(user=self.local_user).count(), 0)
         self.assertFalse(models.ListItem.objects.filter(book=self.book.id).exists())
 
-        with (
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-        ):
-            bookwyrm_import_job.upsert_lists(
-                self.local_user,
-                self.book.id,
-                self.json_data["books"][0]["lists"],
-            )
+        bookwyrm_import_job.upsert_lists(
+            self.local_user,
+            self.book.id,
+            self.json_data["books"][0]["lists"],
+        )
 
         self.assertEqual(models.List.objects.filter(user=self.local_user).count(), 1)
         self.assertEqual(
@@ -693,21 +643,13 @@ class BookwyrmImport(TestCase):
 
         shelf = models.Shelf.objects.get(name="Read", user=self.local_user)
 
-        with (
-            patch("bookwyrm.activitystreams.add_book_statuses_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-        ):
-            models.ShelfBook.objects.create(
-                book=self.book, shelf=shelf, user=self.local_user
-            )
+        models.ShelfBook.objects.create(
+            book=self.book, shelf=shelf, user=self.local_user
+        )
 
-        with (
-            patch("bookwyrm.activitystreams.add_book_statuses_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-        ):
-            bookwyrm_import_job.upsert_shelves(
-                self.local_user, self.book, self.json_data["books"][0].get("shelves")
-            )
+        bookwyrm_import_job.upsert_shelves(
+            self.local_user, self.book, self.json_data["books"][0].get("shelves")
+        )
 
         self.assertEqual(
             models.ShelfBook.objects.filter(user=self.local_user.id).count(), 2
@@ -721,13 +663,9 @@ class BookwyrmImport(TestCase):
             models.ShelfBook.objects.filter(user=self.local_user.id).count(), 0
         )
 
-        with (
-            patch("bookwyrm.activitystreams.add_book_statuses_task.delay"),
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-        ):
-            bookwyrm_import_job.upsert_shelves(
-                self.local_user, self.book, self.json_data["books"][0].get("shelves")
-            )
+        bookwyrm_import_job.upsert_shelves(
+            self.local_user, self.book, self.json_data["books"][0].get("shelves")
+        )
 
         self.assertEqual(
             models.ShelfBook.objects.filter(user=self.local_user.id).count(), 2

--- a/bookwyrm/tests/models/test_federated_server.py
+++ b/bookwyrm/tests/models/test_federated_server.py
@@ -1,6 +1,5 @@
 """testing models"""
 
-from unittest.mock import patch
 from django.test import TestCase
 
 from bookwyrm import models
@@ -12,29 +11,28 @@ class FederatedServer(TestCase):
     def setUp(self):
         """we'll need a user"""
         self.server = models.FederatedServer.objects.create(server_name="test.server")
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            self.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                federated_server=self.server,
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-            self.inactive_remote_user = models.User.objects.create_user(
-                "nutria",
-                "nutria@nutria.com",
-                "nutriaword",
-                federated_server=self.server,
-                local=False,
-                remote_id="https://example.com/users/nutria",
-                inbox="https://example.com/users/nutria/inbox",
-                outbox="https://example.com/users/nutria/outbox",
-                is_active=False,
-                deactivation_reason="self_deletion",
-            )
+        self.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            federated_server=self.server,
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
+        self.inactive_remote_user = models.User.objects.create_user(
+            "nutria",
+            "nutria@nutria.com",
+            "nutriaword",
+            federated_server=self.server,
+            local=False,
+            remote_id="https://example.com/users/nutria",
+            inbox="https://example.com/users/nutria/inbox",
+            outbox="https://example.com/users/nutria/outbox",
+            is_active=False,
+            deactivation_reason="self_deletion",
+        )
 
     def test_block_unblock(self):
         """block a server and all users on it"""

--- a/bookwyrm/tests/models/test_fields.py
+++ b/bookwyrm/tests/models/test_fields.py
@@ -8,7 +8,6 @@ import pathlib
 from urllib.parse import urlparse
 from typing import List
 from unittest import expectedFailure
-from unittest.mock import patch
 
 import responses
 
@@ -26,13 +25,10 @@ from bookwyrm.models.activitypub_mixin import ActivitypubMixin
 from bookwyrm.settings import PROTOCOL, NETLOC
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.populate_lists_task.delay")
 class ModelFields(TestCase):
     """overwrites standard model fields to work with activitypub"""
 
-    def test_validate_remote_id(self, *_):
+    def test_validate_remote_id(self):
         """should look like a url"""
         self.assertIsNone(fields.validate_remote_id("http://www.example.com"))
         self.assertIsNone(fields.validate_remote_id("https://www.example.com"))
@@ -49,7 +45,7 @@ class ModelFields(TestCase):
             "http://www.example.com/dlfjg 23/x",
         )
 
-    def test_activitypub_field_mixin(self, *_):
+    def test_activitypub_field_mixin(self):
         """generic mixin with super basic to and from functionality"""
         instance = fields.ActivitypubFieldMixin()
         self.assertEqual(instance.field_to_activity("fish"), "fish")
@@ -67,7 +63,7 @@ class ModelFields(TestCase):
         instance.name = "snake_case_name"
         self.assertEqual(instance.get_activitypub_field(), "snakeCaseName")
 
-    def test_set_field_from_activity(self, *_):
+    def test_set_field_from_activity(self):
         """setter from entire json blob"""
 
         @dataclass
@@ -86,7 +82,7 @@ class ModelFields(TestCase):
         instance.set_field_from_activity(mock_model, data)
         self.assertEqual(mock_model.field_name, "hi")
 
-    def test_set_activity_from_field(self, *_):
+    def test_set_activity_from_field(self):
         """set json field given entire model"""
 
         @dataclass
@@ -104,7 +100,7 @@ class ModelFields(TestCase):
         instance.set_activity_from_field(data, mock_model)
         self.assertEqual(data["fieldName"], "bip")
 
-    def test_remote_id_field(self, *_):
+    def test_remote_id_field(self):
         """just sets some defaults on charfield"""
         instance = fields.RemoteIdField()
         self.assertEqual(instance.max_length, 255)
@@ -113,7 +109,7 @@ class ModelFields(TestCase):
         with self.assertRaises(ValidationError):
             instance.run_validators("http://www.example.com/dlfjg 23/x")
 
-    def test_username_field(self, *_):
+    def test_username_field(self):
         """again, just setting defaults on username field"""
         instance = fields.UsernameField()
         self.assertEqual(instance.activitypub_field, "preferredUsername")
@@ -134,7 +130,7 @@ class ModelFields(TestCase):
 
         self.assertEqual(instance.field_to_activity("test@example.com"), "test")
 
-    def test_privacy_field_defaults(self, *_):
+    def test_privacy_field_defaults(self):
         """post privacy field's many default values"""
         instance = fields.PrivacyField()
         self.assertEqual(instance.max_length, 255)
@@ -147,17 +143,16 @@ class ModelFields(TestCase):
             instance.public, "https://www.w3.org/ns/activitystreams#Public"
         )
 
-    def test_privacy_field_set_field_from_activity(self, *_):
+    def test_privacy_field_set_field_from_activity(self):
         """translate between to/cc fields and privacy"""
 
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            test_user = User.objects.create_user(
-                username="test_user@example.com",
-                local=False,
-                remote_id="https://example.com/test_user",
-                inbox="https://example.com/users/test_user/inbox",
-                followers_url="https://example.com/users/test_user/followers",
-            )
+        test_user = User.objects.create_user(
+            username="test_user@example.com",
+            local=False,
+            remote_id="https://example.com/test_user",
+            inbox="https://example.com/users/test_user/inbox",
+            followers_url="https://example.com/users/test_user/followers",
+        )
 
         @dataclass(init=False)
         class TestActivity(ActivityObject):
@@ -209,9 +204,7 @@ class ModelFields(TestCase):
         instance.set_field_from_activity(model_instance, data)
         self.assertEqual(model_instance.privacy_field, "followers")
 
-    @patch("bookwyrm.models.activitypub_mixin.ObjectMixin.broadcast")
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_privacy_field_set_activity_from_field(self, *_):
+    def test_privacy_field_set_activity_from_field(self):
         """translate between to/cc fields and privacy"""
         user = User.objects.create_user(
             "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
@@ -255,7 +248,7 @@ class ModelFields(TestCase):
         self.assertEqual(activity["to"], [user.remote_id])
         self.assertEqual(activity["cc"], [])
 
-    def test_foreign_key(self, *_):
+    def test_foreign_key(self):
         """should be able to format a related model"""
         instance = fields.ForeignKey("User", on_delete=models.CASCADE)
         Serializable = namedtuple("Serializable", ("to_activity", "remote_id"))
@@ -264,7 +257,7 @@ class ModelFields(TestCase):
         self.assertEqual(instance.field_to_activity(item), "https://e.b/c")
 
     @responses.activate
-    def test_foreign_key_from_activity_str(self, *_):
+    def test_foreign_key_from_activity_str(self):
         """create a new object from a foreign key"""
         instance = fields.ForeignKey(User, on_delete=models.CASCADE)
         datafile = pathlib.Path(__file__).parent.joinpath("../data/ap_user.json")
@@ -284,14 +277,13 @@ class ModelFields(TestCase):
             json=userdata,
             status=200,
         )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            value = instance.field_from_activity("https://example.com/user/mouse")
+        value = instance.field_from_activity("https://example.com/user/mouse")
         self.assertIsInstance(value, User)
         self.assertNotEqual(value, unrelated_user)
         self.assertEqual(value.remote_id, "https://example.com/user/mouse")
         self.assertEqual(value.name, "MOUSE?? MOUSE!!")
 
-    def test_foreign_key_from_activity_dict(self, *_):
+    def test_foreign_key_from_activity_dict(self):
         """test receiving activity json"""
         instance = fields.ForeignKey(User, on_delete=models.CASCADE)
         datafile = pathlib.Path(__file__).parent.joinpath("../data/ap_user.json")
@@ -303,15 +295,14 @@ class ModelFields(TestCase):
         unrelated_user = User.objects.create_user(
             "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
         )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            value = instance.field_from_activity(activitypub.Person(**userdata))
+        value = instance.field_from_activity(activitypub.Person(**userdata))
         self.assertIsInstance(value, User)
         self.assertNotEqual(value, unrelated_user)
         self.assertEqual(value.remote_id, "https://example.com/user/mouse")
         self.assertEqual(value.name, "MOUSE?? MOUSE!!")
         # et cetera but we're not testing serializing user json
 
-    def test_foreign_key_from_activity_dict_existing(self, *_):
+    def test_foreign_key_from_activity_dict_existing(self):
         """test receiving a dict of an existing object in the db"""
         instance = fields.ForeignKey(User, on_delete=models.CASCADE)
         datafile = pathlib.Path(__file__).parent.joinpath("../data/ap_user.json")
@@ -326,11 +317,10 @@ class ModelFields(TestCase):
             "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
         )
 
-        with patch("bookwyrm.models.activitypub_mixin.ObjectMixin.broadcast"):
-            value = instance.field_from_activity(activitypub.Person(**userdata))
+        value = instance.field_from_activity(activitypub.Person(**userdata))
         self.assertEqual(value, user)
 
-    def test_foreign_key_from_activity_str_existing(self, *_):
+    def test_foreign_key_from_activity_str_existing(self):
         """test receiving a remote id of an existing object in the db"""
         instance = fields.ForeignKey(User, on_delete=models.CASCADE)
         user = User.objects.create_user(
@@ -343,14 +333,14 @@ class ModelFields(TestCase):
         value = instance.field_from_activity(user.remote_id)
         self.assertEqual(value, user)
 
-    def test_one_to_one_field(self, *_):
+    def test_one_to_one_field(self):
         """a gussied up foreign key"""
         instance = fields.OneToOneField("User", on_delete=models.CASCADE)
         Serializable = namedtuple("Serializable", ("to_activity", "remote_id"))
         item = Serializable(lambda: {"a": "b"}, "https://e.b/c")
         self.assertEqual(instance.field_to_activity(item), {"a": "b"})
 
-    def test_many_to_many_field(self, *_):
+    def test_many_to_many_field(self):
         """lists!"""
         instance = fields.ManyToManyField("User")
 
@@ -368,7 +358,7 @@ class ModelFields(TestCase):
         self.assertEqual(instance.field_to_activity(items), "example.com/snake_case")
 
     @responses.activate
-    def test_many_to_many_field_from_activity(self, *_):
+    def test_many_to_many_field_from_activity(self):
         """resolve related fields for a list, takes a list of remote ids"""
         instance = fields.ManyToManyField(User)
         datafile = pathlib.Path(__file__).parent.joinpath("../data/ap_user.json")
@@ -380,15 +370,12 @@ class ModelFields(TestCase):
         responses.add(
             responses.GET, "https://example.com/user/mouse", json=userdata, status=200
         )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            value = instance.field_from_activity(
-                ["https://example.com/user/mouse", "bleh"]
-            )
+        value = instance.field_from_activity(["https://example.com/user/mouse", "bleh"])
         self.assertIsInstance(value, list)
         self.assertEqual(len(value), 1)
         self.assertIsInstance(value[0], User)
 
-    def test_tag_field(self, *_):
+    def test_tag_field(self):
         """a special type of many to many field"""
         instance = fields.TagField("User")
 
@@ -407,13 +394,11 @@ class ModelFields(TestCase):
         self.assertEqual(result[0].name, "@Name")
         self.assertEqual(result[0].type, "Serializable")
 
-    def test_tag_field_from_activity(self, *_):
+    def test_tag_field_from_activity(self):
         """loadin' a list of items from Links"""
         # TODO
 
-    @patch("bookwyrm.models.activitypub_mixin.ObjectMixin.broadcast")
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    def test_image_field_to_activity(self, *_):
+    def test_image_field_to_activity(self):
         """serialize an image field to activitypub"""
         user = User.objects.create_user(
             "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
@@ -435,7 +420,7 @@ class ModelFields(TestCase):
         self.assertEqual(output.type, "Image")
 
     @responses.activate
-    def test_image_field_from_activity(self, *_):
+    def test_image_field_from_activity(self):
         """load an image from activitypub"""
         image_file = pathlib.Path(__file__).parent.joinpath(
             "../../static/images/default_avi.jpg"
@@ -456,7 +441,7 @@ class ModelFields(TestCase):
         self.assertIsInstance(loaded_image[1], ContentFile)
 
     @responses.activate
-    def test_image_field_set_field_from_activity(self, *_):
+    def test_image_field_set_field_from_activity(self):
         """update a model instance from an activitypub object"""
         image_file = pathlib.Path(__file__).parent.joinpath(
             "../../static/images/default_avi.jpg"
@@ -482,7 +467,7 @@ class ModelFields(TestCase):
         self.assertIsNotNone(book.cover.name)
 
     @responses.activate
-    def test_image_field_set_field_from_activity_no_overwrite_no_cover(self, *_):
+    def test_image_field_set_field_from_activity_no_overwrite_no_cover(self):
         """update a model instance from an activitypub object"""
         image_file = pathlib.Path(__file__).parent.joinpath(
             "../../static/images/default_avi.jpg"
@@ -508,7 +493,7 @@ class ModelFields(TestCase):
         self.assertIsNotNone(book.cover.name)
 
     @responses.activate
-    def test_image_field_set_field_from_activity_no_overwrite_with_cover(self, *_):
+    def test_image_field_set_field_from_activity_no_overwrite_with_cover(self):
         """update a model instance from an activitypub object"""
         image_path = pathlib.Path(__file__).parent.joinpath(
             "../../static/images/default_avi.jpg"
@@ -540,7 +525,7 @@ class ModelFields(TestCase):
         self.assertEqual(book.cover.size, cover_size)
 
     @responses.activate
-    def test_image_field_set_field_from_activity_with_overwrite_with_cover(self, *_):
+    def test_image_field_set_field_from_activity_with_overwrite_with_cover(self):
         """update a model instance from an activitypub object"""
         image_path = pathlib.Path(__file__).parent.joinpath(
             "../../static/images/default_avi.jpg"
@@ -575,7 +560,7 @@ class ModelFields(TestCase):
         self.assertIsNotNone(book.cover.name)
         self.assertNotEqual(book.cover.size, cover_size)
 
-    def test_datetime_field(self, *_):
+    def test_datetime_field(self):
         """this one is pretty simple, it just has to use isoformat"""
         instance = fields.DateTimeField()
         now = timezone.now()
@@ -583,7 +568,7 @@ class ModelFields(TestCase):
         self.assertEqual(instance.field_from_activity(now.isoformat()), now)
         self.assertEqual(instance.field_from_activity("bip"), None)
 
-    def test_partial_date_legacy_formats(self, *_):
+    def test_partial_date_legacy_formats(self):
         """test support for full isoformat in partial dates"""
         instance = fields.PartialDateField()
         expected = datetime.date(2023, 10, 20)
@@ -604,7 +589,7 @@ class ModelFields(TestCase):
                 self.assertTrue(parsed.has_month)
 
     @expectedFailure
-    def test_partial_date_timezone_fix(self, *_):
+    def test_partial_date_timezone_fix(self):
         """deserialization compensates for unwanted effects of USE_TZ"""
         instance = fields.PartialDateField()
         expected = datetime.date(2023, 10, 1)
@@ -613,12 +598,12 @@ class ModelFields(TestCase):
         self.assertTrue(parsed.has_day)
         self.assertTrue(parsed.has_month)
 
-    def test_array_field(self, *_):
+    def test_array_field(self):
         """idk why it makes them strings but probably for a good reason"""
         instance = fields.ArrayField(fields.IntegerField)
         self.assertEqual(instance.field_to_activity([0, 1]), ["0", "1"])
 
-    def test_html_field(self, *_):
+    def test_html_field(self):
         """sanitizes html, the sanitizer has its own tests"""
         instance = fields.HtmlField()
         self.assertEqual(

--- a/bookwyrm/tests/models/test_group.py
+++ b/bookwyrm/tests/models/test_group.py
@@ -1,47 +1,39 @@
 """testing models"""
 
-from unittest.mock import patch
 from django.test import TestCase
 
 from bookwyrm import models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class Group(TestCase):
     """some activitypub oddness ahead"""
 
     @classmethod
     def setUpTestData(cls):
         """Set up for tests"""
+        cls.owner_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
+        )
 
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.owner_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
+        cls.rat = models.User.objects.create_user(
+            "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
+        )
 
-            cls.rat = models.User.objects.create_user(
-                "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
-            )
+        cls.badger = models.User.objects.create_user(
+            "badger",
+            "badger@badger.badger",
+            "badgerword",
+            local=True,
+            localname="badger",
+        )
 
-            cls.badger = models.User.objects.create_user(
-                "badger",
-                "badger@badger.badger",
-                "badgerword",
-                local=True,
-                localname="badger",
-            )
-
-            cls.capybara = models.User.objects.create_user(
-                "capybara",
-                "capybara@capybara.capybara",
-                "capybaraword",
-                local=True,
-                localname="capybara",
-            )
+        cls.capybara = models.User.objects.create_user(
+            "capybara",
+            "capybara@capybara.capybara",
+            "capybaraword",
+            local=True,
+            localname="capybara",
+        )
 
         cls.public_group = models.Group.objects.create(
             name="Public Group",
@@ -70,7 +62,7 @@ class Group(TestCase):
         )
         models.GroupMember.objects.create(group=cls.public_group, user=cls.capybara)
 
-    def test_group_members_can_see_private_groups(self, _):
+    def test_group_members_can_see_private_groups(self):
         """direct privacy group should not be excluded from group listings for group
         members viewing"""
 
@@ -80,21 +72,16 @@ class Group(TestCase):
         self.assertFalse(self.private_group in rat_groups)
         self.assertTrue(self.private_group in badger_groups)
 
-    def test_group_members_can_see_followers_only_lists(self, _):
+    def test_group_members_can_see_followers_only_lists(self):
         """follower-only group booklists should not be excluded from group booklist
         listing for group members who do not follower list owner"""
-
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            followers_list = models.List.objects.create(
-                name="Followers List",
-                curation="group",
-                privacy="followers",
-                group=self.public_group,
-                user=self.owner_user,
-            )
+        followers_list = models.List.objects.create(
+            name="Followers List",
+            curation="group",
+            privacy="followers",
+            group=self.public_group,
+            user=self.owner_user,
+        )
 
         rat_lists = models.List.privacy_filter(self.rat).all()
         badger_lists = models.List.privacy_filter(self.badger).all()
@@ -104,21 +91,16 @@ class Group(TestCase):
         self.assertFalse(followers_list in badger_lists)
         self.assertTrue(followers_list in capybara_lists)
 
-    def test_group_members_can_see_private_lists(self, _):
+    def test_group_members_can_see_private_lists(self):
         """private group booklists should not be excluded from group booklist listing
         for group members"""
-
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            private_list = models.List.objects.create(
-                name="Private List",
-                privacy="direct",
-                curation="group",
-                group=self.public_group,
-                user=self.owner_user,
-            )
+        private_list = models.List.objects.create(
+            name="Private List",
+            privacy="direct",
+            curation="group",
+            group=self.public_group,
+            user=self.owner_user,
+        )
 
         rat_lists = models.List.privacy_filter(self.rat).all()
         badger_lists = models.List.privacy_filter(self.badger).all()

--- a/bookwyrm/tests/models/test_housekeeping.py
+++ b/bookwyrm/tests/models/test_housekeeping.py
@@ -37,29 +37,25 @@ from bookwyrm.models.housekeeping import delete_user_export_file_task
 class TestCleanUpExportFiles(TestCase):
     """export and import files should be deleted periodically"""
 
-    def setUp(self):
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            self.user = User.objects.create_user(
-                f"mouse@{DOMAIN}",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                name="hi",
-                summary="a summary",
-                bookwyrm_user=False,
-            )
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            f"mouse@{DOMAIN}",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            name="hi",
+            summary="a summary",
+            bookwyrm_user=False,
+        )
 
-            expiry_date = datetime.now(timezone.utc) - timedelta(hours=2)
-            self.job = CleanUpUserExportFilesJob.objects.create(
-                user=self.user, expiry_date=expiry_date
-            )
+        expiry_date = datetime.now(timezone.utc) - timedelta(hours=2)
+        cls.job = CleanUpUserExportFilesJob.objects.create(
+            user=cls.user, expiry_date=expiry_date
+        )
 
-            SiteSettings.objects.create()
+        SiteSettings.objects.create()
 
     def test_export_file_deleted(self, *_):
         """did the file actually get deleted?"""
@@ -242,9 +238,7 @@ class Covers(TestCase):
         """create a job and add coverless editions to it"""
 
         self.assertEqual(FindMissingCoversJob.objects.count(), 0)
-
-        with patch("bookwyrm.models.housekeeping.get_missing_cover_task.delay"):
-            run_missing_covers_job(user_id=self.user.id)
+        run_missing_covers_job(user_id=self.user.id)
 
         self.assertEqual(FindMissingCoversJob.objects.count(), 1)
         job = FindMissingCoversJob.objects.first()
@@ -259,9 +253,7 @@ class Covers(TestCase):
             self.second_edition.save(update_fields=["cover"])
 
             self.assertEqual(FindMissingCoversJob.objects.count(), 0)
-
-            with patch("bookwyrm.models.housekeeping.get_missing_cover_task.delay"):
-                run_missing_covers_job(user_id=self.user.id, type="wrong_path")
+            run_missing_covers_job(user_id=self.user.id, type="wrong_path")
 
             self.assertEqual(FindMissingCoversJob.objects.count(), 1)
             edition = FindMissingCoversJob.objects.first().editions.first()

--- a/bookwyrm/tests/models/test_import_model.py
+++ b/bookwyrm/tests/models/test_import_model.py
@@ -20,14 +20,9 @@ class ImportJob(TestCase):
     @classmethod
     def setUpTestData(cls):
         """data is from a goodreads export of The Raven Tower"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
 
     def setUp(self):
         self.job = models.ImportJob.objects.create(user=self.local_user, mappings={})
@@ -196,15 +191,12 @@ class ImportJob(TestCase):
         )
 
         with (
-            patch("bookwyrm.connectors.abstract_connector.load_more_data.delay"),
             patch(
-                "bookwyrm.connectors.connector_manager.first_search_result"
-            ) as search,
+                "bookwyrm.connectors.connector_manager.first_search_result",
+                return_value=result,
+            ),
+            patch("bookwyrm.connectors.openlibrary.Connector.get_authors_from_data"),
         ):
-            search.return_value = result
-            with patch(
-                "bookwyrm.connectors.openlibrary.Connector.get_authors_from_data"
-            ):
-                book = item.get_book_from_identifier()
+            book = item.get_book_from_identifier()
 
         self.assertEqual(book.title, "Sabriel")

--- a/bookwyrm/tests/models/test_job.py
+++ b/bookwyrm/tests/models/test_job.py
@@ -1,7 +1,5 @@
 """testing models"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import models
@@ -14,14 +12,9 @@ class TestParentJob(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we're trying to transport user data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
 
     def test_complete_job(self):
         """mark a job as complete"""
@@ -63,14 +56,9 @@ class TestChildJob(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we're trying to transport user data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True
+        )
 
     def test_complete_job(self):
         """a child job completed, so its parent is complete"""

--- a/bookwyrm/tests/models/test_link.py
+++ b/bookwyrm/tests/models/test_link.py
@@ -1,28 +1,26 @@
 """testing models"""
 
-from unittest.mock import patch
 from django.test import TestCase
 
 from bookwyrm import models
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class Link(TestCase):
     """some activitypub oddness ahead"""
 
-    def test_create_domain(self, _):
+    def test_create_domain(self):
         """generated default name"""
         domain = models.LinkDomain.objects.create(domain="beep.com")
         self.assertEqual(domain.name, "beep.com")
         self.assertEqual(domain.status, "pending")
 
-    def test_create_link_new_domain(self, _):
+    def test_create_link_new_domain(self):
         """generates link and sets domain"""
         link = models.Link.objects.create(url="https://www.hello.com/hi-there")
         self.assertEqual(link.domain.domain, "www.hello.com")
         self.assertEqual(link.name, "www.hello.com")
 
-    def test_create_link_existing_domain(self, _):
+    def test_create_link_existing_domain(self):
         """generate link with a known domain"""
         domain = models.LinkDomain.objects.create(domain="www.hello.com", name="Hi")
 

--- a/bookwyrm/tests/models/test_list.py
+++ b/bookwyrm/tests/models/test_list.py
@@ -1,38 +1,30 @@
 """testing models"""
 
 from uuid import UUID
-from unittest.mock import patch
 from django.test import TestCase
 
 from bookwyrm import models, settings
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.lists_stream.remove_list_task.delay")
 class List(TestCase):
     """some activitypub oddness ahead"""
 
     @classmethod
     def setUpTestData(cls):
         """look, a list"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
+        )
         work = models.Work.objects.create(title="hello")
         cls.book = models.Edition.objects.create(title="hi", parent_work=work)
 
-    def test_remote_id(self, *_):
+    def test_remote_id(self):
         """shelves use custom remote ids"""
         book_list = models.List.objects.create(name="Test List", user=self.local_user)
         expected_id = f"{settings.BASE_URL}/list/{book_list.id}"
         self.assertEqual(book_list.get_remote_id(), expected_id)
 
-    def test_to_activity(self, *_):
+    def test_to_activity(self):
         """jsonify it"""
         book_list = models.List.objects.create(name="Test List", user=self.local_user)
         activity_json = book_list.to_activity()
@@ -43,7 +35,7 @@ class List(TestCase):
         self.assertEqual(activity_json["name"], "Test List")
         self.assertEqual(activity_json["owner"], self.local_user.remote_id)
 
-    def test_list_item(self, *_):
+    def test_list_item(self):
         """a list entry"""
         book_list = models.List.objects.create(
             name="Test List", user=self.local_user, privacy="unlisted"
@@ -60,7 +52,7 @@ class List(TestCase):
         self.assertEqual(item.privacy, "unlisted")
         self.assertEqual(item.recipients, [])
 
-    def test_list_item_pending(self, *_):
+    def test_list_item_pending(self):
         """a list entry"""
         book_list = models.List.objects.create(name="Test List", user=self.local_user)
 
@@ -77,7 +69,7 @@ class List(TestCase):
         self.assertEqual(item.privacy, "direct")
         self.assertEqual(item.recipients, [])
 
-    def test_embed_key(self, *_):
+    def test_embed_key(self):
         """embed_key should never be empty"""
         book_list = models.List.objects.create(name="Test List", user=self.local_user)
 

--- a/bookwyrm/tests/models/test_move.py
+++ b/bookwyrm/tests/models/test_move.py
@@ -1,6 +1,5 @@
 """testing move models"""
 
-from unittest.mock import patch
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 
@@ -13,25 +12,18 @@ class MoveUser(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need some users for this"""
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.target_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.origin_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.com", "mouseword", local=True, localname="mouse"
-            )
+        cls.target_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
+        cls.origin_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.com", "mouseword", local=True, localname="mouse"
+        )
         cls.origin_user.remote_id = "http://local.com/user/mouse"
         cls.origin_user.save(broadcast=False, update_fields=["remote_id"])
 
@@ -45,9 +37,7 @@ class MoveUser(TestCase):
                 target=self.target_user,
             )
 
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_user_move(self, *_):
+    def test_user_move(self):
         """move user"""
 
         self.target_user.also_known_as.add(self.origin_user.id)

--- a/bookwyrm/tests/models/test_notification.py
+++ b/bookwyrm/tests/models/test_notification.py
@@ -1,6 +1,5 @@
 """testing models"""
 
-from unittest.mock import patch
 from django.test import TestCase
 from bookwyrm import models
 
@@ -11,27 +10,21 @@ class Notification(TestCase):
     @classmethod
     def setUpTestData(cls):
         """useful things for creating a notification"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
-            cls.another_user = models.User.objects.create_user(
-                "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
+        )
+        cls.another_user = models.User.objects.create_user(
+            "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Test Book",
@@ -109,9 +102,7 @@ class Notification(TestCase):
         )
         self.assertFalse(models.Notification.objects.exists())
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.lists_stream.remove_list_task.delay")
-    def test_notify_list_item_own_list(self, *_):
+    def test_notify_list_item_own_list(self):
         """Don't add list item notification for your own list"""
         test_list = models.List.objects.create(user=self.local_user, name="hi")
 
@@ -120,9 +111,7 @@ class Notification(TestCase):
         )
         self.assertFalse(models.Notification.objects.exists())
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.lists_stream.remove_list_task.delay")
-    def test_notify_list_item_remote(self, *_):
+    def test_notify_list_item_remote(self):
         """Don't add list item notification for a remote user"""
         test_list = models.List.objects.create(user=self.remote_user, name="hi")
 
@@ -131,9 +120,7 @@ class Notification(TestCase):
         )
         self.assertFalse(models.Notification.objects.exists())
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.lists_stream.remove_list_task.delay")
-    def test_notify_list_item(self, *_):
+    def test_notify_list_item(self):
         """Add list item notification"""
         test_list = models.List.objects.create(user=self.local_user, name="hi")
         list_item = models.ListItem.objects.create(
@@ -204,19 +191,14 @@ class NotifyInviteRequest(TestCase):
     @classmethod
     def setUpTestData(cls):
         """ensure there is one admin"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-                is_superuser=True,
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+            is_superuser=True,
+        )
 
     def test_invite_request_triggers_notification(self):
         """requesting an invite notifies the admin"""
@@ -269,22 +251,17 @@ class NotifyInviteRequest(TestCase):
 
     def test_notify_multiple_admins(self):
         """all admins are notified"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            self.local_user = models.User.objects.create_user(
-                "admin@local.com",
-                "admin@example.com",
-                "password",
-                local=True,
-                localname="root",
-                is_superuser=True,
-            )
-            models.InviteRequest.objects.create(email="user@example.com")
-            admins = models.User.objects.filter(is_superuser=True).all()
-            notifications = models.Notification.objects.all()
+        self.local_user = models.User.objects.create_user(
+            "admin@local.com",
+            "admin@example.com",
+            "password",
+            local=True,
+            localname="root",
+            is_superuser=True,
+        )
+        models.InviteRequest.objects.create(email="user@example.com")
+        admins = models.User.objects.filter(is_superuser=True).all()
+        notifications = models.Notification.objects.all()
 
-            self.assertEqual(len(notifications), 2)
-            self.assertCountEqual([notif.user for notif in notifications], admins)
+        self.assertEqual(len(notifications), 2)
+        self.assertCountEqual([notif.user for notif in notifications], admins)

--- a/bookwyrm/tests/models/test_readthrough_model.py
+++ b/bookwyrm/tests/models/test_readthrough_model.py
@@ -1,7 +1,6 @@
 """testing models"""
 
 import datetime
-from unittest.mock import patch
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -15,15 +14,9 @@ class ReadThrough(TestCase):
     @classmethod
     def setUpTestData(cls):
         """look, a shelf"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
-
+        cls.user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
+        )
         cls.work = models.Work.objects.create(title="Example Work")
         cls.edition = models.Edition.objects.create(
             title="Example Edition", parent_work=cls.work

--- a/bookwyrm/tests/models/test_relationship_models.py
+++ b/bookwyrm/tests/models/test_relationship_models.py
@@ -8,38 +8,28 @@ from django.test import TestCase
 from bookwyrm import models
 
 
-@patch("bookwyrm.activitystreams.add_user_statuses_task.delay")
-@patch("bookwyrm.activitystreams.remove_user_statuses_task.delay")
-@patch("bookwyrm.lists_stream.add_user_lists_task.delay")
-@patch("bookwyrm.lists_stream.remove_user_lists_task.delay")
 class Relationship(TestCase):
     """following, blocking, stuff like that"""
 
     @classmethod
     def setUpTestData(cls):
         """we need some users for this"""
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.com", "mouseword", local=True, localname="mouse"
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.com", "mouseword", local=True, localname="mouse"
+        )
         cls.local_user.remote_id = "http://local.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
 
-    def test_user_follows(self, *_):
+    def test_user_follows(self):
         """basic functionality of user follows"""
         relationship = models.UserFollows.objects.create(
             user_subject=self.local_user, user_object=self.remote_user
@@ -52,19 +42,18 @@ class Relationship(TestCase):
             f"http://local.com/user/mouse#follows/{relationship.id}",
         )
 
-    def test_user_follows_blocks(self, *_):
+    def test_user_follows_blocks(self):
         """can't follow if you're blocked"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.UserBlocks.objects.create(
-                user_subject=self.local_user, user_object=self.remote_user
-            )
+        models.UserBlocks.objects.create(
+            user_subject=self.local_user, user_object=self.remote_user
+        )
 
         with self.assertRaises(IntegrityError):
             models.UserFollows.objects.create(
                 user_subject=self.local_user, user_object=self.remote_user
             )
 
-    def test_user_follows_from_request(self, *_):
+    def test_user_follows_from_request(self):
         """convert a follow request into a follow"""
         with patch(
             "bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"
@@ -87,14 +76,13 @@ class Relationship(TestCase):
         self.assertEqual(rel.user_subject, self.local_user)
         self.assertEqual(rel.user_object, self.remote_user)
 
-    def test_user_follows_from_request_custom_remote_id(self, *_):
+    def test_user_follows_from_request_custom_remote_id(self):
         """store a specific remote id for a relationship provided by remote"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            request = models.UserFollowRequest.objects.create(
-                user_subject=self.local_user,
-                user_object=self.remote_user,
-                remote_id="http://antoher.server/sdkfhskdjf/23",
-            )
+        request = models.UserFollowRequest.objects.create(
+            user_subject=self.local_user,
+            user_object=self.remote_user,
+            remote_id="http://antoher.server/sdkfhskdjf/23",
+        )
         self.assertEqual(request.remote_id, "http://antoher.server/sdkfhskdjf/23")
         self.assertEqual(request.status, "follow_request")
 
@@ -105,7 +93,7 @@ class Relationship(TestCase):
         self.assertEqual(rel.user_object, self.remote_user)
 
     @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_follow_request_activity(self, broadcast_mock, *_):
+    def test_follow_request_activity(self, broadcast_mock):
         """accept a request and make it a relationship"""
         models.UserFollowRequest.objects.create(
             user_subject=self.local_user,
@@ -117,7 +105,7 @@ class Relationship(TestCase):
         self.assertEqual(activity["type"], "Follow")
 
     @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_follow_request_accept(self, broadcast_mock, *_):
+    def test_follow_request_accept(self, broadcast_mock):
         """accept a request and make it a relationship"""
         self.local_user.manually_approves_followers = True
         self.local_user.save(
@@ -143,7 +131,7 @@ class Relationship(TestCase):
         self.assertEqual(rel.user_object, self.local_user)
 
     @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_follow_request_reject(self, broadcast_mock, *_):
+    def test_follow_request_reject(self, broadcast_mock):
         """accept a request and make it a relationship"""
         self.local_user.manually_approves_followers = True
         self.local_user.save(

--- a/bookwyrm/tests/models/test_shelf_model.py
+++ b/bookwyrm/tests/models/test_shelf_model.py
@@ -7,43 +7,31 @@ from django.test import TestCase
 from bookwyrm import models, settings
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.populate_lists_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.activitystreams.remove_book_statuses_task.delay")
 class Shelf(TestCase):
     """some activitypub oddness ahead"""
 
     @classmethod
     def setUpTestData(cls):
         """look, a shelf"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(title="test book", parent_work=work)
 
-    def test_remote_id(self, *_):
+    def test_remote_id(self):
         """shelves use custom remote ids"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            shelf = models.Shelf.objects.create(
-                name="Test Shelf", identifier="test-shelf", user=self.local_user
-            )
+        shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=self.local_user
+        )
         expected_id = f"{settings.BASE_URL}/user/mouse/books/test-shelf"
         self.assertEqual(shelf.get_remote_id(), expected_id)
 
-    def test_to_activity(self, *_):
+    def test_to_activity(self):
         """jsonify it"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            shelf = models.Shelf.objects.create(
-                name="Test Shelf", identifier="test-shelf", user=self.local_user
-            )
+        shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=self.local_user
+        )
         activity_json = shelf.to_activity()
         self.assertIsInstance(activity_json, dict)
         self.assertEqual(activity_json["id"], shelf.remote_id)
@@ -52,9 +40,8 @@ class Shelf(TestCase):
         self.assertEqual(activity_json["name"], "Test Shelf")
         self.assertEqual(activity_json["owner"], self.local_user.remote_id)
 
-    def test_create_update_shelf(self, *_):
+    def test_create_update_shelf(self):
         """create and broadcast shelf creation"""
-
         with patch(
             "bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"
         ) as mock:
@@ -77,13 +64,11 @@ class Shelf(TestCase):
         self.assertEqual(activity["object"]["name"], "arthur russel")
         self.assertEqual(shelf.name, "arthur russel")
 
-    def test_shelve(self, *_):
+    def test_shelve(self):
         """create and broadcast shelf creation"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            shelf = models.Shelf.objects.create(
-                name="Test Shelf", identifier="test-shelf", user=self.local_user
-            )
-
+        shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=self.local_user
+        )
         with patch(
             "bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"
         ) as mock:

--- a/bookwyrm/tests/models/test_site.py
+++ b/bookwyrm/tests/models/test_site.py
@@ -1,7 +1,6 @@
 """testing models"""
 
 from datetime import timedelta
-from unittest.mock import patch
 
 from django.db import IntegrityError
 from django.test import TestCase
@@ -16,19 +15,14 @@ class SiteModels(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
 
     def test_site_settings_absent(self):
         """create and load site settings"""
@@ -98,11 +92,7 @@ class SiteModels(TestCase):
         self.assertTrue(token.valid())
         self.assertEqual(token.link, f"{settings.BASE_URL}/password-reset/hello")
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    @patch("bookwyrm.lists_stream.populate_lists_task.delay")
-    def test_change_confirmation_scheme(self, *_):
+    def test_change_confirmation_scheme(self):
         """Switch from requiring email confirmation to not"""
         site = models.SiteSettings.objects.create(
             id=1, name="Fish Town", require_confirm_email=True

--- a/bookwyrm/tests/models/test_status_model.py
+++ b/bookwyrm/tests/models/test_status_model.py
@@ -14,33 +14,24 @@ import responses
 from bookwyrm import activitypub, models, settings
 
 
-@patch("bookwyrm.models.Status.broadcast")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class Status(TestCase):
     """lotta types of statuses"""
 
     @classmethod
     def setUpTestData(cls):
         """useful things for creating a status"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "mouseword", local=True, localname="mouse"
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.book = models.Edition.objects.create(title="Test Edition")
 
     def setUp(self):
@@ -50,20 +41,17 @@ class Status(TestCase):
         image_path = pathlib.Path(__file__).parent.joinpath(
             "../../static/images/default_avi.jpg"
         )
-        with (
-            patch("bookwyrm.models.Status.broadcast"),
-            open(image_path, "rb") as image_file,
-        ):
+        with open(image_path, "rb") as image_file:
             self.book.cover.save("test.jpg", image_file)
 
-    def test_status_generated_fields(self, *_):
+    def test_status_generated_fields(self):
         """setting remote id"""
         status = models.Status.objects.create(content="bleh", user=self.local_user)
         expected_id = f"{settings.BASE_URL}/user/mouse/status/{status.id}"
         self.assertEqual(status.remote_id, expected_id)
         self.assertEqual(status.privacy, "public")
 
-    def test_replies(self, *_):
+    def test_replies(self):
         """get a list of replies"""
         parent = models.Status(content="hi", user=self.local_user)
         parent.save(broadcast=False)
@@ -91,7 +79,7 @@ class Status(TestCase):
         self.assertEqual(sibling.thread_id, parent.id)
         self.assertEqual(grandchild.thread_id, parent.id)
 
-    def test_status_type(self, *_):
+    def test_status_type(self):
         """class name"""
         self.assertEqual(models.Status().status_type, "Note")
         self.assertEqual(models.Review().status_type, "Review")
@@ -99,14 +87,14 @@ class Status(TestCase):
         self.assertEqual(models.Comment().status_type, "Comment")
         self.assertEqual(models.Boost().status_type, "Announce")
 
-    def test_boostable(self, *_):
+    def test_boostable(self):
         """can a status be boosted, based on privacy"""
         self.assertTrue(models.Status(privacy="public").boostable)
         self.assertTrue(models.Status(privacy="unlisted").boostable)
         self.assertFalse(models.Status(privacy="followers").boostable)
         self.assertFalse(models.Status(privacy="direct").boostable)
 
-    def test_to_replies(self, *_):
+    def test_to_replies(self):
         """activitypub replies collection"""
         parent = models.Status.objects.create(content="hi", user=self.local_user)
         child = models.Status.objects.create(
@@ -123,7 +111,7 @@ class Status(TestCase):
         self.assertEqual(replies["id"], f"{parent.remote_id}/replies")
         self.assertEqual(replies["totalItems"], 2)
 
-    def test_status_to_activity(self, *_):
+    def test_status_to_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Status.objects.create(
             content="test content", user=self.local_user
@@ -134,7 +122,7 @@ class Status(TestCase):
         self.assertEqual(activity["content"], "<p>test content</p>")
         self.assertEqual(activity["sensitive"], False)
 
-    def test_status_with_hashtag_to_activity(self, *_):
+    def test_status_with_hashtag_to_activity(self):
         """status with hashtag with a "pure" serializer"""
         tag = models.Hashtag.objects.create(name="#content")
         status = models.Status.objects.create(
@@ -153,7 +141,7 @@ class Status(TestCase):
             activity["tag"][0]["href"], f"{settings.BASE_URL}/hashtag/{tag.id}"
         )
 
-    def test_status_with_mention_to_activity(self, *_):
+    def test_status_with_mention_to_activity(self):
         """status with mention with a "pure" serializer"""
         status = models.Status.objects.create(
             content="test @rat@rat.com", user=self.local_user
@@ -169,7 +157,7 @@ class Status(TestCase):
         self.assertEqual(activity["tag"][0]["name"], f"@{self.remote_user.username}")
         self.assertEqual(activity["tag"][0]["href"], self.remote_user.remote_id)
 
-    def test_status_to_activity_tombstone(self, *_):
+    def test_status_to_activity_tombstone(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Status.objects.create(
             content="test content",
@@ -182,7 +170,7 @@ class Status(TestCase):
         self.assertEqual(activity["type"], "Tombstone")
         self.assertFalse(hasattr(activity, "content"))
 
-    def test_status_to_pure_activity(self, *_):
+    def test_status_to_pure_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Status.objects.create(
             content="test content", user=self.local_user
@@ -194,7 +182,7 @@ class Status(TestCase):
         self.assertEqual(activity["sensitive"], False)
         self.assertEqual(activity["attachment"], [])
 
-    def test_generated_note_to_activity(self, *_):
+    def test_generated_note_to_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.GeneratedNote.objects.create(
             content="test content", user=self.local_user
@@ -208,7 +196,7 @@ class Status(TestCase):
         self.assertEqual(activity["sensitive"], False)
         self.assertEqual(len(activity["tag"]), 2)
 
-    def test_generated_note_to_pure_activity(self, *_):
+    def test_generated_note_to_pure_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.GeneratedNote.objects.create(
             content="reads", user=self.local_user
@@ -232,7 +220,7 @@ class Status(TestCase):
         )
         self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
-    def test_comment_to_activity(self, *_):
+    def test_comment_to_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Comment.objects.create(
             content="test content", user=self.local_user, book=self.book
@@ -243,7 +231,7 @@ class Status(TestCase):
         self.assertEqual(activity["content"], "<p>test content</p>")
         self.assertEqual(activity["inReplyToBook"], self.book.remote_id)
 
-    def test_comment_to_pure_activity(self, *_):
+    def test_comment_to_pure_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Comment.objects.create(
             content="test content", user=self.local_user, book=self.book, progress=27
@@ -266,7 +254,7 @@ class Status(TestCase):
         )
         self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
-    def test_quotation_to_activity(self, *_):
+    def test_quotation_to_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Quotation.objects.create(
             quote="a sickening sense",
@@ -281,7 +269,7 @@ class Status(TestCase):
         self.assertEqual(activity["content"], "<p>test content</p>")
         self.assertEqual(activity["inReplyToBook"], self.book.remote_id)
 
-    def test_quotation_to_pure_activity(self, *_):
+    def test_quotation_to_pure_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Quotation.objects.create(
             quote="a sickening sense",
@@ -307,7 +295,7 @@ class Status(TestCase):
         )
         self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
-    def test_quotation_with_author_to_pure_activity(self, *_):
+    def test_quotation_with_author_to_pure_activity(self):
         """serialization of quotation of a book with author and edition info"""
         self.book.authors.set([models.Author.objects.create(name="Author Name")])
         self.book.physical_format = "worm"
@@ -330,7 +318,7 @@ class Status(TestCase):
             activity["attachment"][0]["name"], "Author Name: Test Edition (worm)"
         )
 
-    def test_quotation_page_serialization(self, *_):
+    def test_quotation_page_serialization(self):
         """serialization of quotation page position"""
         tests = [
             ("single pos", "7", "", "p. 7"),
@@ -358,7 +346,7 @@ class Status(TestCase):
                     expect_re = '^<p>"my quote"</p> <p>— <a .+</a></p>$'
                 self.assertRegex(activity["content"], expect_re)
 
-    def test_review_to_activity(self, *_):
+    def test_review_to_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Review.objects.create(
             name="Review name",
@@ -375,7 +363,7 @@ class Status(TestCase):
         self.assertEqual(activity["content"], "<p>test content</p>")
         self.assertEqual(activity["inReplyToBook"], self.book.remote_id)
 
-    def test_review_to_pure_activity(self, *_):
+    def test_review_to_pure_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Review.objects.create(
             name="Review's name",
@@ -399,7 +387,7 @@ class Status(TestCase):
         )
         self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
-    def test_review_to_pure_activity_no_rating(self, *_):
+    def test_review_to_pure_activity_no_rating(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.Review.objects.create(
             name="Review name",
@@ -422,7 +410,7 @@ class Status(TestCase):
         )
         self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
-    def test_reviewrating_to_pure_activity(self, *_):
+    def test_reviewrating_to_pure_activity(self):
         """subclass of the base model version with a "pure" serializer"""
         status = models.ReviewRating.objects.create(
             rating=3.0,
@@ -443,7 +431,7 @@ class Status(TestCase):
         )
         self.assertEqual(activity["attachment"][0]["name"], "Test Edition")
 
-    def test_favorite(self, *_):
+    def test_favorite(self):
         """fav a status"""
         status = models.Status.objects.create(
             content="test content", user=self.local_user
@@ -464,7 +452,7 @@ class Status(TestCase):
         self.assertEqual(activity["actor"], self.local_user.remote_id)
         self.assertEqual(activity["object"], status.remote_id)
 
-    def test_boost(self, *_):
+    def test_boost(self):
         """boosting, this one's a bit fussy"""
         status = models.Status.objects.create(
             content="test content", user=self.local_user
@@ -476,7 +464,8 @@ class Status(TestCase):
         self.assertEqual(activity["type"], "Announce")
         self.assertEqual(activity, boost.to_activity(pure=True))
 
-    def test_create_broadcast(self, one, two, broadcast_mock, *_):
+    @patch("bookwyrm.models.Status.broadcast")
+    def test_create_broadcast(self, broadcast_mock):
         """should send out two versions of a status on create"""
         models.Comment.objects.create(
             content="hi", user=self.local_user, book=self.book
@@ -496,7 +485,7 @@ class Status(TestCase):
         self.assertEqual(args["type"], "Create")
         self.assertEqual(args["object"]["type"], "Comment")
 
-    def test_recipients_with_mentions(self, *_):
+    def test_recipients_with_mentions(self):
         """get recipients to broadcast a status"""
         status = models.GeneratedNote.objects.create(
             content="test content", user=self.local_user
@@ -505,7 +494,7 @@ class Status(TestCase):
 
         self.assertEqual(status.recipients, [self.remote_user])
 
-    def test_recipients_with_reply_parent(self, *_):
+    def test_recipients_with_reply_parent(self):
         """get recipients to broadcast a status"""
         parent_status = models.GeneratedNote.objects.create(
             content="test content", user=self.remote_user
@@ -516,7 +505,7 @@ class Status(TestCase):
 
         self.assertEqual(status.recipients, [self.remote_user])
 
-    def test_recipients_with_reply_parent_and_mentions(self, *_):
+    def test_recipients_with_reply_parent_and_mentions(self):
         """get recipients to broadcast a status"""
         parent_status = models.GeneratedNote.objects.create(
             content="test content", user=self.remote_user
@@ -529,7 +518,7 @@ class Status(TestCase):
         self.assertEqual(status.recipients, [self.remote_user])
 
     @responses.activate
-    def test_ignore_activity_boost(self, *_):
+    def test_ignore_activity_boost(self):
         """don't bother with most remote statuses"""
         responses.add(responses.GET, "http://fish.com/nothing")
 
@@ -546,7 +535,7 @@ class Status(TestCase):
 
         self.assertTrue(models.Status.ignore_activity(activity))
 
-    def test_raise_visible_to_user_public(self, *_):
+    def test_raise_visible_to_user_public(self):
         """privacy settings"""
         status = models.Status.objects.create(
             content="bleh", user=self.local_user, privacy="public"
@@ -555,7 +544,7 @@ class Status(TestCase):
         self.assertIsNone(status.raise_visible_to_user(self.local_user))
         self.assertIsNone(status.raise_visible_to_user(self.anonymous_user))
 
-    def test_raise_visible_to_user_unlisted(self, *_):
+    def test_raise_visible_to_user_unlisted(self):
         """privacy settings"""
         status = models.Status.objects.create(
             content="bleh", user=self.local_user, privacy="unlisted"
@@ -564,8 +553,7 @@ class Status(TestCase):
         self.assertIsNone(status.raise_visible_to_user(self.local_user))
         self.assertIsNone(status.raise_visible_to_user(self.anonymous_user))
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    def test_raise_visible_to_user_followers(self, *_):
+    def test_raise_visible_to_user_followers(self):
         """privacy settings"""
         status = models.Status.objects.create(
             content="bleh", user=self.local_user, privacy="followers"
@@ -579,7 +567,7 @@ class Status(TestCase):
         self.local_user.followers.add(self.remote_user)
         self.assertIsNone(status.raise_visible_to_user(self.remote_user))
 
-    def test_raise_visible_to_user_followers_mentioned(self, *_):
+    def test_raise_visible_to_user_followers_mentioned(self):
         """privacy settings"""
         status = models.Status.objects.create(
             content="bleh", user=self.local_user, privacy="followers"
@@ -587,8 +575,7 @@ class Status(TestCase):
         status.mention_users.set([self.remote_user])
         self.assertIsNone(status.raise_visible_to_user(self.remote_user))
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    def test_raise_visible_to_user_direct(self, *_):
+    def test_raise_visible_to_user_direct(self):
         """privacy settings"""
         status = models.Status.objects.create(
             content="bleh", user=self.local_user, privacy="direct"

--- a/bookwyrm/tests/models/test_unicode_slugs.py
+++ b/bookwyrm/tests/models/test_unicode_slugs.py
@@ -1,7 +1,7 @@
 """Test Unicode slug generation and URL routing"""
 
 import re
-from unittest.mock import patch
+
 from django.test import TestCase
 from django.utils.text import slugify
 
@@ -15,19 +15,13 @@ class UnicodeSlugTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Set up test data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "testuser",
-                "test@example.com",
-                "password",
-                local=True,
-                localname="testuser",
-            )
-        models.SiteSettings.objects.create()
+        cls.local_user = models.User.objects.create_user(
+            "testuser",
+            "test@example.com",
+            "password",
+            local=True,
+            localname="testuser",
+        )
 
     def test_unicode_characters_in_slug_generation(self):
         """Test that Unicode characters are preserved in slugs"""

--- a/bookwyrm/tests/models/test_user_model.py
+++ b/bookwyrm/tests/models/test_user_model.py
@@ -16,30 +16,25 @@ from bookwyrm.settings import DOMAIN, BASE_URL
 class User(TestCase):
     @classmethod
     def setUpTestData(cls):
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                f"mouse@{DOMAIN}",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                name="hi",
-                summary="a summary",
-                bookwyrm_user=False,
-            )
-            cls.another_user = models.User.objects.create_user(
-                f"nutria@{DOMAIN}",
-                "nutria@nutria.nutria",
-                "nutriaword",
-                local=True,
-                localname="nutria",
-                name="hi",
-                bookwyrm_user=False,
-            )
+        cls.user = models.User.objects.create_user(
+            f"mouse@{DOMAIN}",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            name="hi",
+            summary="a summary",
+            bookwyrm_user=False,
+        )
+        cls.another_user = models.User.objects.create_user(
+            f"nutria@{DOMAIN}",
+            "nutria@nutria.nutria",
+            "nutriaword",
+            local=True,
+            localname="nutria",
+            name="hi",
+            bookwyrm_user=False,
+        )
         initdb.init_groups()
         initdb.init_permissions()
 
@@ -57,15 +52,14 @@ class User(TestCase):
         self.assertIsNotNone(self.user.key_pair.public_key)
 
     def test_remote_user(self):
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.rat",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/dfjkg",
-                bookwyrm_user=False,
-            )
+        user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.rat",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/dfjkg",
+            bookwyrm_user=False,
+        )
         self.assertEqual(user.username, "rat@example.com")
 
     def test_user_shelves(self):
@@ -121,32 +115,22 @@ class User(TestCase):
 
         site.default_user_auth_group = Group.objects.get(name="editor")
         site.save()
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            user = models.User.objects.create_user(
-                "test2",
-                "test2@bookwyrm.test",
-                localname="test2",
-                **user_attrs,
-            )
+        user = models.User.objects.create_user(
+            "test2",
+            "test2@bookwyrm.test",
+            localname="test2",
+            **user_attrs,
+        )
         self.assertEqual(list(user.groups.all()), [Group.objects.get(name="editor")])
 
         site.default_user_auth_group = None
         site.save()
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            user = models.User.objects.create_user(
-                "test1",
-                "test1@bookwyrm.test",
-                localname="test1",
-                **user_attrs,
-            )
+        user = models.User.objects.create_user(
+            "test1",
+            "test1@bookwyrm.test",
+            localname="test1",
+            **user_attrs,
+        )
         self.assertEqual(len(user.groups.all()), 0)
 
     def test_set_remote_server(self):
@@ -224,8 +208,7 @@ class User(TestCase):
         self.assertIsNone(server.application_type)
         self.assertIsNone(server.application_version)
 
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    def test_delete_user(self, _):
+    def test_delete_user(self):
         """permanently delete a user"""
         self.assertTrue(self.user.is_active)
         self.assertEqual(self.user.name, "hi")
@@ -257,11 +240,7 @@ class User(TestCase):
         self.assertNotEqual(self.user.email, "mouse@mouse.mouse")
         self.assertFalse(self.user.is_active)
 
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    @patch("bookwyrm.activitystreams.remove_status_task.delay")
-    def test_delete_user_erase_statuses(self, *_):
+    def test_delete_user_erase_statuses(self):
         """erase user statuses when user is deleted"""
         status = models.Status.objects.create(user=self.user, content="hello")
         self.assertFalse(status.deleted)
@@ -275,10 +254,7 @@ class User(TestCase):
         self.assertIsNone(status.content)
         self.assertIsNotNone(status.deleted_date)
 
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_delete_user_erase_statuses_invalid(self, *_):
+    def test_delete_user_erase_statuses_invalid(self):
         """erase user statuses when user is deleted"""
         status = models.Status.objects.create(user=self.user, content="hello")
         self.assertFalse(status.deleted)

--- a/bookwyrm/tests/templatetags/test_book_display_tags.py
+++ b/bookwyrm/tests/templatetags/test_book_display_tags.py
@@ -8,9 +8,6 @@ from bookwyrm import models
 from bookwyrm.templatetags import book_display_tags
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class BookDisplayTags(TestCase):
     """lotta different things here"""
 
@@ -31,7 +28,7 @@ class BookDisplayTags(TestCase):
             )
         cls.book = models.Edition.objects.create(title="Test Book")
 
-    def test_get_book_description(self, *_):
+    def test_get_book_description(self):
         """grab it from the edition or the parent"""
         work = models.Work.objects.create(title="Test Work")
         self.book.parent_work = work
@@ -47,7 +44,7 @@ class BookDisplayTags(TestCase):
         self.book.save()
         self.assertEqual(book_display_tags.get_book_description(self.book), "hello")
 
-    def test_get_book_file_links(self, *_):
+    def test_get_book_file_links(self):
         """load approved links"""
         link = models.FileLink.objects.create(
             book=self.book,

--- a/bookwyrm/tests/templatetags/test_feed_page_tags.py
+++ b/bookwyrm/tests/templatetags/test_feed_page_tags.py
@@ -1,37 +1,27 @@
 """style fixes and lookups for templates"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import models
 from bookwyrm.templatetags import feed_page_tags
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class FeedPageTags(TestCase):
     """lotta different things here"""
 
     @classmethod
     def setUpTestData(cls):
         """create some filler objects"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.book = models.Edition.objects.create(title="Test Book")
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_load_subclass(self, *_):
+    def test_load_subclass(self):
         """get a status' real type"""
         review = models.Review.objects.create(user=self.user, book=self.book, rating=3)
         status = models.Status.objects.get(id=review.id)

--- a/bookwyrm/tests/templatetags/test_interaction.py
+++ b/bookwyrm/tests/templatetags/test_interaction.py
@@ -1,57 +1,45 @@
 """style fixes and lookups for templates"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import models
 from bookwyrm.templatetags import interaction
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class InteractionTags(TestCase):
     """lotta different things here"""
 
     @classmethod
     def setUpTestData(cls):
         """create some filler objects"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.rat",
-                "ratword",
-                remote_id="http://example.com/rat",
-                local=False,
-            )
+        cls.user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.rat",
+            "ratword",
+            remote_id="http://example.com/rat",
+            local=False,
+        )
         cls.book = models.Edition.objects.create(title="Test Book")
 
-    def test_get_user_liked(self, *_):
+    def test_get_user_liked(self):
         """did a user like a status"""
         status = models.Review.objects.create(user=self.remote_user, book=self.book)
 
         self.assertFalse(interaction.get_user_liked(self.user, status))
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.Favorite.objects.create(user=self.user, status=status)
+        models.Favorite.objects.create(user=self.user, status=status)
         self.assertTrue(interaction.get_user_liked(self.user, status))
 
-    def test_get_user_boosted(self, *_):
+    def test_get_user_boosted(self):
         """did a user boost a status"""
         status = models.Review.objects.create(user=self.remote_user, book=self.book)
 
         self.assertFalse(interaction.get_user_boosted(self.user, status))
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.Boost.objects.create(user=self.user, boosted_status=status)
+        models.Boost.objects.create(user=self.user, boosted_status=status)
         self.assertTrue(interaction.get_user_boosted(self.user, status))

--- a/bookwyrm/tests/templatetags/test_notification_page_tags.py
+++ b/bookwyrm/tests/templatetags/test_notification_page_tags.py
@@ -1,38 +1,28 @@
 """style fixes and lookups for templates"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import models
 from bookwyrm.templatetags import notification_page_tags
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class NotificationPageTags(TestCase):
     """lotta different things here"""
 
     @classmethod
     def setUpTestData(cls):
         """create some filler objects"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
 
-    def test_related_status(self, *_):
+    def test_related_status(self):
         """gets the subclass model for a notification status"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Status.objects.create(content="hi", user=self.user)
+        status = models.Status.objects.create(content="hi", user=self.user)
         notification = models.Notification.objects.create(
             user=self.user, notification_type="MENTION", related_status=status
         )

--- a/bookwyrm/tests/templatetags/test_rating_tags.py
+++ b/bookwyrm/tests/templatetags/test_rating_tags.py
@@ -1,49 +1,38 @@
 """Gettings book ratings"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import models
 from bookwyrm.templatetags import rating_tags
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class RatingTags(TestCase):
     """lotta different things here"""
 
     @classmethod
     def setUpTestData(cls):
         """create some filler objects"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.rat",
-                "ratword",
-                remote_id="http://example.com/rat",
-                local=False,
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.rat",
+            "ratword",
+            remote_id="http://example.com/rat",
+            local=False,
+        )
         work = models.Work.objects.create(title="Work title")
         cls.book = models.Edition.objects.create(
             title="Test Book",
             parent_work=work,
         )
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_get_rating(self, *_):
+    def test_get_rating(self):
         """privacy filtered rating. Commented versions are how it ought to work with
         subjective ratings, which are currently not used for performance reasons."""
         # follows-only: not included
@@ -75,18 +64,17 @@ class RatingTags(TestCase):
         )
         self.assertEqual(rating_tags.get_rating(self.book, self.local_user), 5)
 
-    def test_get_rating_broken_edition(self, *_):
+    def test_get_rating_broken_edition(self):
         """Don't have a server error if an edition is missing a work"""
         broken_book = models.Edition.objects.create(title="Test")
         broken_book.parent_work = None
         self.assertIsNone(rating_tags.get_rating(broken_book, self.local_user))
 
-    def test_get_user_rating(self, *_):
+    def test_get_user_rating(self):
         """get a user's most recent rating of a book"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.Review.objects.create(user=self.local_user, book=self.book, rating=3)
+        models.Review.objects.create(user=self.local_user, book=self.book, rating=3)
         self.assertEqual(rating_tags.get_user_rating(self.book, self.local_user), 3)
 
-    def test_get_user_rating_doesnt_exist(self, *_):
+    def test_get_user_rating_doesnt_exist(self):
         """there is no rating available"""
         self.assertEqual(rating_tags.get_user_rating(self.book, self.local_user), 0)

--- a/bookwyrm/tests/templatetags/test_shelf_tags.py
+++ b/bookwyrm/tests/templatetags/test_shelf_tags.py
@@ -1,7 +1,5 @@
 """style fixes and lookups for templates"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 from django.test.client import RequestFactory
 
@@ -9,36 +7,26 @@ from bookwyrm import models
 from bookwyrm.templatetags import shelf_tags
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class ShelfTags(TestCase):
     """lotta different things here"""
 
     @classmethod
     def setUpTestData(cls):
         """create some filler objects"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.rat",
-                "ratword",
-                remote_id="http://example.com/rat",
-                local=False,
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.rat",
+            "ratword",
+            remote_id="http://example.com/rat",
+            local=False,
+        )
         cls.book = models.Edition.objects.create(
             title="Test Book",
             parent_work=models.Work.objects.create(title="Test work"),
@@ -48,7 +36,7 @@ class ShelfTags(TestCase):
         """test data"""
         self.factory = RequestFactory()
 
-    def test_get_is_book_on_shelf(self, *_):
+    def test_get_is_book_on_shelf(self):
         """check if a book is on a shelf"""
         shelf = self.local_user.shelf_set.first()
         self.assertFalse(shelf_tags.get_is_book_on_shelf(self.book, shelf))
@@ -57,14 +45,14 @@ class ShelfTags(TestCase):
         )
         self.assertTrue(shelf_tags.get_is_book_on_shelf(self.book, shelf))
 
-    def test_get_next_shelf(self, *_):
+    def test_get_next_shelf(self):
         """self progress helper"""
         self.assertEqual(shelf_tags.get_next_shelf("to-read"), "reading")
         self.assertEqual(shelf_tags.get_next_shelf("reading"), "read")
         self.assertEqual(shelf_tags.get_next_shelf("read"), "complete")
         self.assertEqual(shelf_tags.get_next_shelf("blooooga"), "to-read")
 
-    def test_active_shelf(self, *_):
+    def test_active_shelf(self):
         """get the shelf a book is on"""
         shelf = self.local_user.shelf_set.first()
         request = self.factory.get("")

--- a/bookwyrm/tests/templatetags/test_status_display.py
+++ b/bookwyrm/tests/templatetags/test_status_display.py
@@ -10,44 +10,35 @@ from bookwyrm import models
 from bookwyrm.templatetags import status_display
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class StatusDisplayTags(TestCase):
     """lotta different things here"""
 
     @classmethod
     def setUpTestData(cls):
         """create some filler objects"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.rat",
-                "ratword",
-                remote_id="http://example.com/rat",
-                local=False,
-            )
+        cls.user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.rat",
+            "ratword",
+            remote_id="http://example.com/rat",
+            local=False,
+        )
         cls.book = models.Edition.objects.create(title="Test Book")
 
-    def test_get_mentions(self, *_):
+    def test_get_mentions(self):
         """list of people mentioned"""
         status = models.Status.objects.create(content="hi", user=self.remote_user)
         result = status_display.get_mentions(status, self.user)
         self.assertEqual(result, "@rat@example.com ")
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_get_replies(self, *_):
+    def test_get_replies(self):
         """direct replies to a status"""
         parent = models.Review.objects.create(
             user=self.user, book=self.book, content="hi"
@@ -71,30 +62,27 @@ class StatusDisplayTags(TestCase):
         self.assertTrue(second_child in replies)
         self.assertFalse(third_child in replies)
 
-    def test_get_parent(self, *_):
+    def test_get_parent(self):
         """get the reply parent of a status"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            parent = models.Review.objects.create(
-                user=self.user, book=self.book, content="hi"
-            )
-            child = models.Status.objects.create(
-                reply_parent=parent, user=self.user, content="hi"
-            )
-
+        parent = models.Review.objects.create(
+            user=self.user, book=self.book, content="hi"
+        )
+        child = models.Status.objects.create(
+            reply_parent=parent, user=self.user, content="hi"
+        )
         result = status_display.get_parent(child)
         self.assertEqual(result, parent)
         self.assertIsInstance(result, models.Review)
 
-    def test_get_boosted(self, *_):
+    def test_get_boosted(self):
         """load a boosted status"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Review.objects.create(user=self.remote_user, book=self.book)
-            boost = models.Boost.objects.create(user=self.user, boosted_status=status)
+        status = models.Review.objects.create(user=self.remote_user, book=self.book)
+        boost = models.Boost.objects.create(user=self.user, boosted_status=status)
         boosted = status_display.get_boosted(boost)
         self.assertIsInstance(boosted, models.Review)
         self.assertEqual(boosted, status)
 
-    def test_get_published_date(self, *_):
+    def test_get_published_date(self):
         """date formatting"""
         date = datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
         with patch("django.utils.timezone.now") as timezone_mock:

--- a/bookwyrm/tests/templatetags/test_utilities.py
+++ b/bookwyrm/tests/templatetags/test_utilities.py
@@ -2,7 +2,6 @@
 
 from collections import namedtuple
 import re
-from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -10,65 +9,57 @@ from bookwyrm import models
 from bookwyrm.templatetags import utilities
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class UtilitiesTags(TestCase):
     """lotta different things here"""
 
     @classmethod
     def setUpTestData(cls):
         """create some filler objects"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.mouse",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.rat",
-                "ratword",
-                remote_id="http://example.com/rat",
-                local=False,
-            )
+        cls.user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.mouse",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.rat",
+            "ratword",
+            remote_id="http://example.com/rat",
+            local=False,
+        )
         cls.author = models.Author.objects.create(name="Jessica", isni="4")
         cls.book = models.Edition.objects.create(title="Test Book")
 
-    def test_get_uuid(self, *_):
+    def test_get_uuid(self):
         """uuid functionality"""
         uuid = utilities.get_uuid("hi")
         self.assertTrue(re.match(r"hi[A-Za-z0-9\-]", uuid))
 
-    def test_join(self, *_):
+    def test_join(self):
         """concats things with underscores"""
         self.assertEqual(utilities.join("hi", 5, "blah", 0.75), "hi_5_blah_0.75")
 
-    def test_get_user_identifer_local(self, *_):
+    def test_get_user_identifer_local(self):
         """fall back to the simplest uid available"""
         self.assertNotEqual(self.user.username, self.user.localname)
         self.assertEqual(utilities.get_user_identifier(self.user), "mouse")
 
-    def test_get_user_identifer_remote(self, *_):
+    def test_get_user_identifer_remote(self):
         """for a remote user, should be their full username"""
         self.assertEqual(
             utilities.get_user_identifier(self.remote_user), "rat@example.com"
         )
 
-    def test_get_title(self, *_):
+    def test_get_title(self):
         """the title of a book"""
         self.assertEqual(utilities.get_title(None), "")
         self.assertEqual(utilities.get_title(self.book), "Test Book")
         book = models.Edition.objects.create(title="Oh", subtitle="oh my")
         self.assertEqual(utilities.get_title(book), "Oh: oh my")
 
-    def test_comparison_bool(self, *_):
+    def test_comparison_bool(self):
         """just a simple comparison"""
         self.assertTrue(utilities.comparison_bool("a", "a"))
         self.assertFalse(utilities.comparison_bool("a", "b"))
@@ -76,14 +67,14 @@ class UtilitiesTags(TestCase):
         self.assertFalse(utilities.comparison_bool("a", "a", reverse=True))
         self.assertTrue(utilities.comparison_bool("a", "b", reverse=True))
 
-    def test_truncatepath(self, *_):
+    def test_truncatepath(self):
         """truncate a path"""
         ValueMock = namedtuple("Value", ("name"))
         value = ValueMock("home/one/two/three/four")
         self.assertEqual(utilities.truncatepath(value, 2), "home/…ur")
         self.assertEqual(utilities.truncatepath(value, "a"), "four")
 
-    def test_get_isni_bio(self, *_):
+    def test_get_isni_bio(self):
         """get ISNI bio"""
         DataMock = namedtuple("Data", ("bio", "isni"))
         data = [DataMock(r"One\Dtwo", "4"), DataMock("Not used", "4")]

--- a/bookwyrm/tests/test_context_processors.py
+++ b/bookwyrm/tests/test_context_processors.py
@@ -1,6 +1,5 @@
 """test for context processor"""
 
-from unittest.mock import patch
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -15,18 +14,13 @@ class ContextProcessor(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         cls.anonymous_user = AnonymousUser
         cls.anonymous_user.is_authenticated = False
         cls.site = models.SiteSettings.get()

--- a/bookwyrm/tests/test_emailing.py
+++ b/bookwyrm/tests/test_emailing.py
@@ -15,18 +15,13 @@ class Emailing(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """other test data"""

--- a/bookwyrm/tests/test_preview_images.py
+++ b/bookwyrm/tests/test_preview_images.py
@@ -29,12 +29,7 @@ class PreviewImages(TestCase):
         avatar_path = pathlib.Path(__file__).parent.joinpath(
             "../static/images/no_cover.jpg"
         )
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-            open(avatar_path, "rb") as avatar_file,
-        ):
+        with open(avatar_path, "rb") as avatar_file:
             self.local_user = models.User.objects.create_user(
                 "possum@local.com",
                 "possum@possum.possum",
@@ -48,27 +43,17 @@ class PreviewImages(TestCase):
                 ),
             )
 
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            self.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        self.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-            open(avatar_path, "rb") as avatar_file,
-        ):
+        with open(avatar_path, "rb") as avatar_file:
             self.remote_user_with_preview = models.User.objects.create_user(
                 "badger@your.domain.here",
                 "badger@badger.com",

--- a/bookwyrm/tests/test_signing.py
+++ b/bookwyrm/tests/test_signing.py
@@ -39,24 +39,19 @@ class Signature(TestCase):
     @classmethod
     def setUpTestData(cls):
         """create users and test data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.mouse = models.User.objects.create_user(
-                f"mouse@{DOMAIN}",
-                "mouse@example.com",
-                "",
-                local=True,
-                localname="mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                f"rat@{DOMAIN}", "rat@example.com", "", local=True, localname="rat"
-            )
-            cls.cat = models.User.objects.create_user(
-                f"cat@{DOMAIN}", "cat@example.com", "", local=True, localname="cat"
-            )
+        cls.mouse = models.User.objects.create_user(
+            f"mouse@{DOMAIN}",
+            "mouse@example.com",
+            "",
+            local=True,
+            localname="mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            f"rat@{DOMAIN}", "rat@example.com", "", local=True, localname="rat"
+        )
+        cls.cat = models.User.objects.create_user(
+            f"cat@{DOMAIN}", "cat@example.com", "", local=True, localname="cat"
+        )
 
     def setUp(self):
         """test data"""
@@ -92,11 +87,7 @@ class Signature(TestCase):
         signature = make_signature(
             "post", signer or sender, self.rat.inbox, now, digest=digest
         )
-        with (
-            patch("bookwyrm.views.inbox.activity_task.apply_async"),
-            patch("bookwyrm.models.user.set_remote_server.delay"),
-        ):
-            return self.send(signature, now, send_data or data, digest)
+        return self.send(signature, now, send_data or data, digest)
 
     def test_correct_signature(self):
         """this one should just work"""
@@ -130,13 +121,12 @@ class Signature(TestCase):
             status=200,
         )
 
-        with patch("bookwyrm.models.user.get_remote_reviews.delay"):
-            with patch(
-                "bookwyrm.models.relationship.UserFollowRequest.accept"
-            ) as accept_mock:
-                response = self.send_test_request(sender=self.fake_remote)
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(accept_mock.called)
+        with patch(
+            "bookwyrm.models.relationship.UserFollowRequest.accept"
+        ) as accept_mock:
+            response = self.send_test_request(sender=self.fake_remote)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(accept_mock.called)
 
     @responses.activate
     def test_key_needs_refresh(self):
@@ -158,34 +148,33 @@ class Signature(TestCase):
         data["publicKey"]["publicKeyPem"] = key_pair.public_key
         responses.add(responses.GET, self.fake_remote.remote_id, json=data, status=200)
 
-        with patch("bookwyrm.models.user.get_remote_reviews.delay"):
-            # Key correct:
-            with patch(
-                "bookwyrm.models.relationship.UserFollowRequest.accept"
-            ) as accept_mock:
-                response = self.send_test_request(sender=self.fake_remote)
-            self.assertEqual(response.status_code, 200)  # BUG this is 401
-            self.assertTrue(accept_mock.called)
-
-            # Old key is cached, so still works:
-            with patch(
-                "bookwyrm.models.relationship.UserFollowRequest.accept"
-            ) as accept_mock:
-                response = self.send_test_request(sender=self.fake_remote)
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(accept_mock.called)
-
-            # Try with new key:
-            with patch(
-                "bookwyrm.models.relationship.UserFollowRequest.accept"
-            ) as accept_mock:
-                response = self.send_test_request(sender=new_sender)
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(accept_mock.called)
-
-            # Now the old key will fail:
+        # Key correct:
+        with patch(
+            "bookwyrm.models.relationship.UserFollowRequest.accept"
+        ) as accept_mock:
             response = self.send_test_request(sender=self.fake_remote)
-            self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 200)  # BUG this is 401
+        self.assertTrue(accept_mock.called)
+
+        # Old key is cached, so still works:
+        with patch(
+            "bookwyrm.models.relationship.UserFollowRequest.accept"
+        ) as accept_mock:
+            response = self.send_test_request(sender=self.fake_remote)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(accept_mock.called)
+
+        # Try with new key:
+        with patch(
+            "bookwyrm.models.relationship.UserFollowRequest.accept"
+        ) as accept_mock:
+            response = self.send_test_request(sender=new_sender)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(accept_mock.called)
+
+        # Now the old key will fail:
+        response = self.send_test_request(sender=self.fake_remote)
+        self.assertEqual(response.status_code, 401)
 
     @responses.activate
     def test_nonexistent_signer(self):

--- a/bookwyrm/tests/test_suggested_users.py
+++ b/bookwyrm/tests/test_suggested_users.py
@@ -10,56 +10,43 @@ from bookwyrm import models
 from bookwyrm.suggested_users import suggested_users, get_annotated_users
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.populate_lists_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.suggested_users.rerank_user_task.delay")
-@patch("bookwyrm.suggested_users.remove_user_task.delay")
 class SuggestedUsers(TestCase):
     """using redis to build activity streams"""
 
     def setUp(self):
         """use a test csv"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            self.local_user = models.User.objects.create_user(
-                "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
-            )
+        self.local_user = models.User.objects.create_user(
+            "mouse", "mouse@mouse.mouse", "password", local=True, localname="mouse"
+        )
 
-    def test_get_rank(self, *_):
+    def test_get_rank(self):
         """a float that reflects both the mutuals count and shared books"""
         Mock = namedtuple("AnnotatedUserMock", ("mutuals", "shared_books"))
         annotated_user_mock = Mock(3, 27)
         rank = suggested_users.get_rank(annotated_user_mock)
         self.assertEqual(rank, 3)  # 3.9642857142857144)
 
-    def test_store_id_from_obj(self, *_):
+    def test_store_id_from_obj(self):
         """redis key generation by user obj"""
         self.assertEqual(
             suggested_users.store_id(self.local_user),
             f"{self.local_user.id}-suggestions",
         )
 
-    def test_store_id_from_id(self, *_):
+    def test_store_id_from_id(self):
         """redis key generation by user id"""
         self.assertEqual(
             suggested_users.store_id(self.local_user.id),
             f"{self.local_user.id}-suggestions",
         )
 
-    def test_get_counts_from_rank(self, *_):
+    def test_get_counts_from_rank(self):
         """reverse the rank computation to get the mutuals and shared books counts"""
         counts = suggested_users.get_counts_from_rank(3.9642857142857144)
         self.assertEqual(counts["mutuals"], 3)
         # self.assertEqual(counts["shared_books"], 27)
 
-    def test_get_objects_for_store(self, *_):
+    def test_get_objects_for_store(self):
         """list of people to follow for a given user"""
 
         mutual_user = models.User.objects.create_user(
@@ -87,7 +74,7 @@ class SuggestedUsers(TestCase):
         self.assertEqual(match.id, suggestable_user.id)
         self.assertEqual(match.mutuals, 1)
 
-    def test_get_stores_for_object(self, *_):
+    def test_get_stores_for_object(self):
         """possible follows"""
         mutual_user = models.User.objects.create_user(
             "rat", "rat@local.rat", "password", local=True, localname="rat"
@@ -110,7 +97,7 @@ class SuggestedUsers(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], f"{suggestable_user.id}-suggestions")
 
-    def test_get_users_for_object(self, *_):
+    def test_get_users_for_object(self):
         """given a user, who might want to follow them"""
         mutual_user = models.User.objects.create_user(
             "rat", "rat@local.rat", "password", local=True, localname="rat"
@@ -132,7 +119,7 @@ class SuggestedUsers(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], suggestable_user)
 
-    def test_rerank_user_suggestions(self, *_):
+    def test_rerank_user_suggestions(self):
         """does it call the populate store function correctly"""
         with patch(
             "bookwyrm.suggested_users.SuggestedUsers.populate_store"
@@ -141,7 +128,7 @@ class SuggestedUsers(TestCase):
         args = store_mock.call_args[0]
         self.assertEqual(args[0], f"{self.local_user.id}-suggestions")
 
-    def test_get_suggestions(self, *_):
+    def test_get_suggestions(self):
         """load from store"""
         with patch("bookwyrm.suggested_users.SuggestedUsers.get_store") as mock:
             mock.return_value = [(self.local_user.id, 7.9)]
@@ -149,7 +136,7 @@ class SuggestedUsers(TestCase):
         self.assertEqual(results[0], self.local_user)
         self.assertEqual(results[0].mutuals, 7)
 
-    def test_get_annotated_users(self, *_):
+    def test_get_annotated_users(self):
         """list of people you might know"""
         user_1 = models.User.objects.create_user(
             "nutria@local.com",
@@ -172,20 +159,19 @@ class SuggestedUsers(TestCase):
             remote_id="https://example.com/book/1",
             parent_work=work,
         )
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            # 1 shared follow
-            self.local_user.following.add(user_2)
-            user_1.followers.add(user_2)
+        # 1 shared follow
+        self.local_user.following.add(user_2)
+        user_1.followers.add(user_2)
 
-            # 1 shared book
-            models.ShelfBook.objects.create(
-                user=self.local_user,
-                book=book,
-                shelf=self.local_user.shelf_set.first(),
-            )
-            models.ShelfBook.objects.create(
-                user=user_1, book=book, shelf=user_1.shelf_set.first()
-            )
+        # 1 shared book
+        models.ShelfBook.objects.create(
+            user=self.local_user,
+            book=book,
+            shelf=self.local_user.shelf_set.first(),
+        )
+        models.ShelfBook.objects.create(
+            user=user_1, book=book, shelf=user_1.shelf_set.first()
+        )
 
         result = get_annotated_users(self.local_user)
         self.assertEqual(result.count(), 1)
@@ -196,7 +182,7 @@ class SuggestedUsers(TestCase):
         self.assertEqual(user_1_annotated.mutuals, 1)
         # self.assertEqual(user_1_annotated.shared_books, 1)
 
-    def test_get_annotated_users_counts(self, *_):
+    def test_get_annotated_users_counts(self):
         """correct counting for multiple shared attributed"""
         user_1 = models.User.objects.create_user(
             "nutria@local.com",
@@ -217,20 +203,19 @@ class SuggestedUsers(TestCase):
             user.following.add(user_1)
             user.followers.add(self.local_user)
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            for i in range(3):
-                book = models.Edition.objects.create(
-                    title=i,
-                    parent_work=models.Work.objects.create(title=i),
-                )
-                models.ShelfBook.objects.create(
-                    user=self.local_user,
-                    book=book,
-                    shelf=self.local_user.shelf_set.first(),
-                )
-                models.ShelfBook.objects.create(
-                    user=user_1, book=book, shelf=user_1.shelf_set.first()
-                )
+        for i in range(3):
+            book = models.Edition.objects.create(
+                title=i,
+                parent_work=models.Work.objects.create(title=i),
+            )
+            models.ShelfBook.objects.create(
+                user=self.local_user,
+                book=book,
+                shelf=self.local_user.shelf_set.first(),
+            )
+            models.ShelfBook.objects.create(
+                user=user_1, book=book, shelf=user_1.shelf_set.first()
+            )
 
         result = get_annotated_users(
             self.local_user,

--- a/bookwyrm/tests/views/admin/test_announcements.py
+++ b/bookwyrm/tests/views/admin/test_announcements.py
@@ -1,6 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
 from django.template.response import TemplateResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -15,18 +14,13 @@ class AnnouncementViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """individual test setup"""

--- a/bookwyrm/tests/views/admin/test_automod.py
+++ b/bookwyrm/tests/views/admin/test_automod.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -19,18 +17,13 @@ class AutomodViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="moderator")

--- a/bookwyrm/tests/views/admin/test_celery.py
+++ b/bookwyrm/tests/views/admin/test_celery.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -18,18 +16,13 @@ class CeleryStatusViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="admin")

--- a/bookwyrm/tests/views/admin/test_connectors.py
+++ b/bookwyrm/tests/views/admin/test_connectors.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 import pytest
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
@@ -19,18 +17,13 @@ class ConnectorViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="admin")

--- a/bookwyrm/tests/views/admin/test_dashboard.py
+++ b/bookwyrm/tests/views/admin/test_dashboard.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -18,18 +16,13 @@ class DashboardViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="moderator")

--- a/bookwyrm/tests/views/admin/test_email_blocks.py
+++ b/bookwyrm/tests/views/admin/test_email_blocks.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -18,18 +16,13 @@ class EmailBlocklistViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="moderator")

--- a/bookwyrm/tests/views/admin/test_email_config.py
+++ b/bookwyrm/tests/views/admin/test_email_config.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -18,18 +16,13 @@ class EmailConfigViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="admin")

--- a/bookwyrm/tests/views/admin/test_federation.py
+++ b/bookwyrm/tests/views/admin/test_federation.py
@@ -20,28 +20,22 @@ class FederationViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="moderator")

--- a/bookwyrm/tests/views/admin/test_imports.py
+++ b/bookwyrm/tests/views/admin/test_imports.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -18,18 +16,13 @@ class ImportsAdminViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="admin")

--- a/bookwyrm/tests/views/admin/test_ip_blocklist.py
+++ b/bookwyrm/tests/views/admin/test_ip_blocklist.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -18,18 +16,13 @@ class IPBlocklistViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="moderator")

--- a/bookwyrm/tests/views/admin/test_link_domains.py
+++ b/bookwyrm/tests/views/admin/test_link_domains.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -18,18 +16,13 @@ class LinkDomainViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="moderator")

--- a/bookwyrm/tests/views/admin/test_reports.py
+++ b/bookwyrm/tests/views/admin/test_reports.py
@@ -19,25 +19,20 @@ class ReportViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@mouse.mouse",
-                "password",
-                local=True,
-                localname="rat",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@mouse.mouse",
+            "password",
+            local=True,
+            localname="rat",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="moderator")
@@ -130,10 +125,7 @@ class ReportViews(TestCase):
             ).exists()
         )
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    def test_suspend_user(self, *_):
+    def test_suspend_user(self):
         """toggle whether a user is able to log in"""
         self.assertTrue(self.rat.is_active)
         request = self.factory.post("")
@@ -149,9 +141,7 @@ class ReportViews(TestCase):
         self.rat.refresh_from_db()
         self.assertTrue(self.rat.is_active)
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    def test_delete_user(self, *_):
+    def test_delete_user(self):
         """toggle whether a user is able to log in"""
         self.assertTrue(self.rat.is_active)
         request = self.factory.post("", {"password": "password"})

--- a/bookwyrm/tests/views/admin/test_site.py
+++ b/bookwyrm/tests/views/admin/test_site.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -18,18 +16,13 @@ class SiteSettingsViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="admin")

--- a/bookwyrm/tests/views/admin/test_themes.py
+++ b/bookwyrm/tests/views/admin/test_themes.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.core.exceptions import PermissionDenied
 from django.template.response import TemplateResponse
@@ -19,25 +17,20 @@ class AdminThemesViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.another_user = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@rat.rat",
-                "password",
-                local=True,
-                localname="rat",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.another_user = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@rat.rat",
+            "password",
+            local=True,
+            localname="rat",
+        )
         initdb.init_groups()
         initdb.init_permissions()
         group = Group.objects.get(name="admin")

--- a/bookwyrm/tests/views/admin/test_user_admin.py
+++ b/bookwyrm/tests/views/admin/test_user_admin.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import Group
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -23,39 +21,34 @@ class UserAdminViews(TestCase):
         initdb.init_permissions()
         moderator = Group.objects.get(name="moderator")
         editor = Group.objects.get(name="editor")
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.user_user = models.User.objects.create_user(
-                "user@local.com",
-                "user@user.user",
-                "password",
-                local=True,
-                localname="user",
-            )
-            cls.user_editor = models.User.objects.create_user(
-                "editor@local.com",
-                "editor@editor.editor",
-                "password",
-                local=True,
-                localname="editor",
-            )
-            cls.user_editor_2 = models.User.objects.create_user(
-                "editor_2@local.com",
-                "editor_2@editor_2.editor_2",
-                "password",
-                local=True,
-                localname="editor_2",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.user_user = models.User.objects.create_user(
+            "user@local.com",
+            "user@user.user",
+            "password",
+            local=True,
+            localname="user",
+        )
+        cls.user_editor = models.User.objects.create_user(
+            "editor@local.com",
+            "editor@editor.editor",
+            "password",
+            local=True,
+            localname="editor",
+        )
+        cls.user_editor_2 = models.User.objects.create_user(
+            "editor_2@local.com",
+            "editor_2@editor_2.editor_2",
+            "password",
+            local=True,
+            localname="editor_2",
+        )
         cls.local_user.groups.set([moderator])
         cls.user_editor.groups.set([editor])
         cls.user_editor_2.groups.set([editor])
@@ -87,10 +80,7 @@ class UserAdminViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    def test_user_admin_page_post(self, *_):
+    def test_user_admin_page_post(self):
         """set the user's group"""
         group = Group.objects.get(name="editor")
         self.assertEqual(
@@ -101,8 +91,7 @@ class UserAdminViews(TestCase):
         request = self.factory.post("", {"groups": [group.id]})
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            result = view(request, self.local_user.id)
+        result = view(request, self.local_user.id)
 
         self.assertIsInstance(result, TemplateResponse)
         validate_html(result.render())
@@ -111,10 +100,7 @@ class UserAdminViews(TestCase):
             list(self.local_user.groups.values_list("name", flat=True)), ["editor"]
         )
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    def test_user_admin_page_post_with_report(self, *_):
+    def test_user_admin_page_post_with_report(self):
         """set the user's group"""
         group = Group.objects.get(name="editor")
         self.assertEqual(
@@ -129,8 +115,7 @@ class UserAdminViews(TestCase):
         request = self.factory.post("", {"groups": [group.id]})
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            result = view(request, self.local_user.id, report.id)
+        result = view(request, self.local_user.id, report.id)
 
         self.assertIsInstance(result, TemplateResponse)
         validate_html(result.render())

--- a/bookwyrm/tests/views/books/test_book.py
+++ b/bookwyrm/tests/views/books/test_book.py
@@ -25,19 +25,14 @@ class BookViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         cls.group = Group.objects.create(name="editor")
         cls.group.permissions.add(
             Permission.objects.create(
@@ -81,9 +76,7 @@ class BookViews(TestCase):
         self.assertIsInstance(result, ActivitypubResponse)
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_book_page_statuses(self, *_):
+    def test_book_page_statuses(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Book.as_view()
 
@@ -205,8 +198,7 @@ class BookViews(TestCase):
         request = self.factory.post("", {"description": "new description hi"})
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.add_description(request, self.book.id)
+        views.add_description(request, self.book.id)
 
         self.book.refresh_from_db()
         self.assertEqual(self.book.description, "new description hi")
@@ -260,9 +252,7 @@ class BookViews(TestCase):
         self.assertEqual(mock.call_args[0][0], "https://openlibrary.org/book/123")
         self.assertEqual(result.status_code, 302)
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_quotation_endposition(self, *_):
+    def test_quotation_endposition(self):
         """make sure the endposition is served as well"""
         view = views.Book.as_view()
 

--- a/bookwyrm/tests/views/books/test_edit_book.py
+++ b/bookwyrm/tests/views/books/test_edit_book.py
@@ -23,19 +23,14 @@ class EditBookViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         cls.group = Group.objects.create(name="editor")
         cls.group.permissions.add(
             Permission.objects.create(
@@ -112,8 +107,7 @@ class EditBookViews(TestCase):
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request, self.book.id)
+        view(request, self.book.id)
 
         self.book.refresh_from_db()
         self.assertEqual(self.book.title, "New Title")
@@ -171,8 +165,7 @@ class EditBookViews(TestCase):
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request, self.book.id)
+        view(request, self.book.id)
 
         self.book.refresh_from_db()
         self.assertEqual(self.book.title, "New Title")
@@ -192,8 +185,8 @@ class EditBookViews(TestCase):
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request, self.book.id)
+        view(request, self.book.id)
+
         self.book.refresh_from_db()
         self.assertEqual(self.book.title, "New Title")
         self.assertFalse(self.book.authors.exists())
@@ -269,9 +262,7 @@ class EditBookViews(TestCase):
         request = self.factory.post("", book_data | initial_pub_dates)
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            create_book(request)
-
+        create_book(request)
         book = models.Edition.objects.get(title="An Edition With Dates")
 
         self.assertEqual("2023-01-01", book.published_date.partial_isoformat())
@@ -288,9 +279,7 @@ class EditBookViews(TestCase):
         request = self.factory.post("", book_data | updated_pub_dates)
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            result = edit_book(request, book.id)
-
+        result = edit_book(request, book.id)
         self.assertEqual(result.status_code, 302)
 
         book.refresh_from_db()
@@ -460,8 +449,7 @@ class EditBookViews(TestCase):
         request.user = self.local_user
         request.user.is_superuser = True
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            result = view(request)
+        result = view(request)
         self.assertEqual(result.status_code, 302)
 
         new_edition = models.Edition.objects.get(title="A Title")

--- a/bookwyrm/tests/views/books/test_editions.py
+++ b/bookwyrm/tests/views/books/test_editions.py
@@ -17,19 +17,14 @@ class BookViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -108,38 +103,29 @@ class BookViews(TestCase):
         self.assertIsInstance(result, ActivitypubResponse)
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    @patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-    def test_switch_edition(self, *_):
+    def test_switch_edition(self):
         """updates user's relationships to a book"""
         work = models.Work.objects.create(title="test work")
         edition1 = models.Edition.objects.create(title="first ed", parent_work=work)
         edition2 = models.Edition.objects.create(title="second ed", parent_work=work)
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            shelf = models.Shelf.objects.create(name="Test Shelf", user=self.local_user)
-            models.ShelfBook.objects.create(
-                book=edition1,
-                user=self.local_user,
-                shelf=shelf,
-            )
+        shelf = models.Shelf.objects.create(name="Test Shelf", user=self.local_user)
+        models.ShelfBook.objects.create(
+            book=edition1,
+            user=self.local_user,
+            shelf=shelf,
+        )
         models.ReadThrough.objects.create(user=self.local_user, book=edition1)
 
         self.assertEqual(models.ShelfBook.objects.get().book, edition1)
         self.assertEqual(models.ReadThrough.objects.get().book, edition1)
         request = self.factory.post("", {"edition": edition2.id})
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.switch_edition(request)
 
+        views.switch_edition(request)
         self.assertEqual(models.ShelfBook.objects.get().book, edition2)
         self.assertEqual(models.ReadThrough.objects.get().book, edition2)
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    @patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_move_ratings_on_switch_edition(self, *_):
+    def test_move_ratings_on_switch_edition(self):
         """updates user's rating on a book to new edition"""
         work = models.Work.objects.create(title="test work")
         edition1 = models.Edition.objects.create(title="first ed", parent_work=work)
@@ -169,11 +155,7 @@ class BookViews(TestCase):
         with self.assertRaises(models.ReviewRating.DoesNotExist):
             models.ReviewRating.objects.get(user=self.local_user, book=edition1)
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    @patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_move_reviews_on_switch_edition(self, *_):
+    def test_move_reviews_on_switch_edition(self):
         """updates user's review on a book to new edition"""
         work = models.Work.objects.create(title="test work")
         edition1 = models.Edition.objects.create(title="first ed", parent_work=work)

--- a/bookwyrm/tests/views/books/test_links.py
+++ b/bookwyrm/tests/views/books/test_links.py
@@ -19,18 +19,14 @@ class LinkViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         group = Group.objects.create(name="editor")
         group.permissions.add(
             Permission.objects.create(
@@ -126,14 +122,13 @@ class LinkViews(TestCase):
 
         request = self.factory.post("", data=data)
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            result = view(request, self.book.id)
-            # link is duplicate and we get form page again with error
-            self.assertContains(
-                result,
-                "This link with file type has already been added for this book",
-            )
-            self.assertEqual(result.status_code, 200)
+        result = view(request, self.book.id)
+        # link is duplicate and we get form page again with error
+        self.assertContains(
+            result,
+            "This link with file type has already been added for this book",
+        )
+        self.assertEqual(result.status_code, 200)
 
     def test_book_links(self):
         """there are so many views, this just makes sure it LOADS"""

--- a/bookwyrm/tests/views/imports/test_import.py
+++ b/bookwyrm/tests/views/imports/test_import.py
@@ -20,18 +20,13 @@ class ImportViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -92,8 +87,7 @@ class ImportViews(TestCase):
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
-        with patch("bookwyrm.models.import_job.ImportJob.start_job"):
-            view(request)
+        view(request)
         job = models.ImportJob.objects.get()
         self.assertFalse(job.include_reviews)
         self.assertEqual(job.privacy, "public")

--- a/bookwyrm/tests/views/imports/test_import_review.py
+++ b/bookwyrm/tests/views/imports/test_import_review.py
@@ -15,18 +15,13 @@ class ImportManualReviewViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         cls.job = models.ImportJob.objects.create(user=cls.local_user, mappings={})
 
         work = models.Work.objects.create(title="Test Work")

--- a/bookwyrm/tests/views/imports/test_import_troubleshoot.py
+++ b/bookwyrm/tests/views/imports/test_import_troubleshoot.py
@@ -16,18 +16,13 @@ class ImportTroubleshootViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """individual test setup"""

--- a/bookwyrm/tests/views/imports/test_user_import.py
+++ b/bookwyrm/tests/views/imports/test_user_import.py
@@ -1,7 +1,6 @@
 """test for app action functionality"""
 
 import pathlib
-from unittest.mock import patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template.response import TemplateResponse
@@ -19,18 +18,13 @@ class ImportUserViews(TestCase):
         """we need basic test data and mocks"""
         self.site = models.SiteSettings.get()
         self.factory = RequestFactory()
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            self.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        self.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def test_get_user_import_page(self):
         """there are so many views, this just makes sure it LOADS"""
@@ -64,7 +58,6 @@ class ImportUserViews(TestCase):
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
-        with patch("bookwyrm.models.bookwyrm_import_job.BookwyrmImportJob.start_job"):
-            view(request)
+        view(request)
         job = models.BookwyrmImportJob.objects.get()
         self.assertEqual(job.required, ["include_goals"])

--- a/bookwyrm/tests/views/inbox/test_inbox.py
+++ b/bookwyrm/tests/views/inbox/test_inbox.py
@@ -31,30 +31,24 @@ class Inbox(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         local_user.remote_id = "https://example.com/user/mouse"
         local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
     def test_inbox_invalid_get(self):
         """shouldn't try to handle if the user is not found"""
@@ -122,11 +116,9 @@ class Inbox(TestCase):
         }
         with patch("bookwyrm.views.inbox.has_valid_signature") as mock_valid:
             mock_valid.return_value = True
-
-            with patch("bookwyrm.views.inbox.activity_task.apply_async"):
-                result = self.client.post(
-                    "/inbox", json.dumps(activity), content_type="application/json"
-                )
+            result = self.client.post(
+                "/inbox", json.dumps(activity), content_type="application/json"
+            )
         self.assertEqual(result.status_code, 200)
 
     def test_is_blocked_user_agent(self):
@@ -156,8 +148,7 @@ class Inbox(TestCase):
         with self.assertRaises(PermissionDenied):
             views.inbox.raise_is_blocked_activity(activity)
 
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    def test_create_by_deactivated_user(self, _):
+    def test_create_by_deactivated_user(self):
         """don't let deactivated users post"""
         self.remote_user.delete(broadcast=False)
         self.assertTrue(self.remote_user.deleted)

--- a/bookwyrm/tests/views/inbox/test_inbox_add.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_add.py
@@ -1,7 +1,5 @@
 """tests incoming activities"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 import responses
 
@@ -14,31 +12,24 @@ class InboxAdd(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         local_user.remote_id = "https://example.com/user/mouse"
         local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         work = models.Work.objects.create(title="work title")
         cls.book = models.Edition.objects.create(
             title="Test",

--- a/bookwyrm/tests/views/inbox/test_inbox_announce.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_announce.py
@@ -14,40 +14,29 @@ class InboxActivities(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.local_user.remote_id = "https://example.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_status_task.delay"),
-        ):
-            cls.status = models.Status.objects.create(
-                user=cls.local_user,
-                content="Test status",
-                remote_id="https://example.com/status/1",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
+        cls.status = models.Status.objects.create(
+            user=cls.local_user,
+            content="Test status",
+            remote_id="https://example.com/status/1",
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -60,8 +49,7 @@ class InboxActivities(TestCase):
             "object": {},
         }
 
-    @patch("bookwyrm.activitystreams.handle_boost_task.delay")
-    def test_boost(self, _):
+    def test_boost(self):
         """boost a status"""
         self.assertEqual(models.Notification.objects.count(), 0)
         activity = {
@@ -87,8 +75,7 @@ class InboxActivities(TestCase):
         self.assertEqual(notification.related_status, self.status)
 
     @responses.activate
-    @patch("bookwyrm.activitystreams.handle_boost_task.delay")
-    def test_boost_remote_status(self, _):
+    def test_boost_remote_status(self):
         """boost a status from a remote server"""
         work = models.Work.objects.create(title="work title")
         book = models.Edition.objects.create(
@@ -142,8 +129,7 @@ class InboxActivities(TestCase):
             content="hi",
             user=self.remote_user,
         )
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            status.save(broadcast=False)
+        status.save(broadcast=False)
         activity = {
             "type": "Announce",
             "id": "http://www.faraway.com/boost/12",
@@ -159,10 +145,7 @@ class InboxActivities(TestCase):
         views.inbox.activity_task(activity)
         self.assertEqual(models.Boost.objects.count(), 0)
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    @patch("bookwyrm.activitystreams.handle_boost_task.delay")
-    @patch("bookwyrm.activitystreams.remove_status_task.delay")
-    def test_unboost(self, *_):
+    def test_unboost(self):
         """undo a boost"""
         boost = models.Boost.objects.create(
             boosted_status=self.status, user=self.remote_user

--- a/bookwyrm/tests/views/inbox/test_inbox_block.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_block.py
@@ -13,38 +13,31 @@ class InboxBlock(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.local_user.remote_id = "https://example.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
     def test_handle_blocks(self):
         """create a "block" database entry from an activity"""
         self.local_user.followers.add(self.remote_user)
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.UserFollowRequest.objects.create(
-                user_subject=self.local_user, user_object=self.remote_user
-            )
+        models.UserFollowRequest.objects.create(
+            user_subject=self.local_user, user_object=self.remote_user
+        )
         self.assertTrue(models.UserFollows.objects.exists())
         self.assertTrue(models.UserFollowRequest.objects.exists())
 
@@ -56,12 +49,9 @@ class InboxBlock(TestCase):
             "object": "https://example.com/user/mouse",
         }
 
-        with (
-            patch(
-                "bookwyrm.activitystreams.remove_user_statuses_task.delay"
-            ) as redis_mock,
-            patch("bookwyrm.lists_stream.remove_user_lists_task.delay"),
-        ):
+        with patch(
+            "bookwyrm.activitystreams.remove_user_statuses_task.delay"
+        ) as redis_mock:
             views.inbox.activity_task(activity)
             self.assertTrue(redis_mock.called)
         views.inbox.activity_task(activity)
@@ -73,10 +63,7 @@ class InboxBlock(TestCase):
         self.assertFalse(models.UserFollows.objects.exists())
         self.assertFalse(models.UserFollowRequest.objects.exists())
 
-    @patch("bookwyrm.activitystreams.remove_user_statuses_task.delay")
-    @patch("bookwyrm.lists_stream.add_user_lists_task.delay")
-    @patch("bookwyrm.lists_stream.remove_user_lists_task.delay")
-    def test_handle_unblock(self, *_):
+    def test_handle_unblock(self):
         """unblock a user"""
         self.remote_user.blocks.add(self.local_user)
 

--- a/bookwyrm/tests/views/inbox/test_inbox_create.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_create.py
@@ -15,31 +15,24 @@ class TransactionInboxCreate(TransactionTestCase):
 
     def setUp(self):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            self.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        self.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         self.local_user.remote_id = "https://example.com/user/mouse"
         self.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            self.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-
+        self.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         self.create_json = {
             "id": "hi",
             "type": "Create",
@@ -49,7 +42,7 @@ class TransactionInboxCreate(TransactionTestCase):
             "object": {},
         }
 
-    def test_create_status_transaction(self, *_):
+    def test_create_status_transaction(self):
         """the "it justs works" mode"""
         datafile = pathlib.Path(__file__).parent.joinpath(
             "../../data/ap_quotation.json"
@@ -67,38 +60,30 @@ class TransactionInboxCreate(TransactionTestCase):
         self.assertEqual(mock.call_count, 0)
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class InboxCreate(TestCase):
     """readthrough tests"""
 
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.local_user.remote_id = "https://example.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
         models.SiteSettings.objects.create()
 
@@ -113,7 +98,7 @@ class InboxCreate(TestCase):
             "object": {},
         }
 
-    def test_create_status(self, *_):
+    def test_create_status(self):
         """the "it justs works" mode"""
         datafile = pathlib.Path(__file__).parent.joinpath(
             "../../data/ap_quotation.json"
@@ -141,7 +126,7 @@ class InboxCreate(TestCase):
         views.inbox.activity_task(activity)
         self.assertEqual(models.Status.objects.count(), 1)
 
-    def test_create_comment_with_reading_status(self, *_):
+    def test_create_comment_with_reading_status(self):
         """the "it justs works" mode"""
         datafile = pathlib.Path(__file__).parent.joinpath("../../data/ap_comment.json")
         status_data = json.loads(datafile.read_bytes())
@@ -165,7 +150,7 @@ class InboxCreate(TestCase):
         views.inbox.activity_task(activity)
         self.assertEqual(models.Status.objects.count(), 1)
 
-    def test_create_status_remote_note_with_mention(self, *_):
+    def test_create_status_remote_note_with_mention(self):
         """should only create it under the right circumstances"""
         self.assertFalse(
             models.Notification.objects.filter(user=self.local_user).exists()
@@ -186,7 +171,7 @@ class InboxCreate(TestCase):
         )
         self.assertEqual(models.Notification.objects.get().notification_type, "MENTION")
 
-    def test_create_status_remote_note_with_reply(self, *_):
+    def test_create_status_remote_note_with_reply(self):
         """should only create it under the right circumstances"""
         parent_status = models.Status.objects.create(
             user=self.local_user,
@@ -212,7 +197,7 @@ class InboxCreate(TestCase):
         self.assertTrue(models.Notification.objects.filter(user=self.local_user))
         self.assertEqual(models.Notification.objects.get().notification_type, "REPLY")
 
-    def test_create_rating(self, *_):
+    def test_create_rating(self):
         """a remote rating activity"""
         book = models.Edition.objects.create(
             title="Test Book", remote_id="https://example.com/book/1"
@@ -247,7 +232,7 @@ class InboxCreate(TestCase):
         self.assertEqual(rating.book, book)
         self.assertEqual(rating.rating, 3.0)
 
-    def test_create_list(self, *_):
+    def test_create_list(self):
         """a new list"""
         activity = self.create_json
         activity["object"] = {
@@ -271,7 +256,7 @@ class InboxCreate(TestCase):
         self.assertEqual(book_list.description, "summary text")
         self.assertEqual(book_list.remote_id, "https://example.com/list/22")
 
-    def test_create_unsupported_type_question(self, *_):
+    def test_create_unsupported_type_question(self):
         """ignore activities we know we can't handle"""
         activity = self.create_json
         activity["object"] = {
@@ -281,7 +266,7 @@ class InboxCreate(TestCase):
         # just observe how it doesn't throw an error
         views.inbox.activity_task(activity)
 
-    def test_create_unsupported_type_article(self, *_):
+    def test_create_unsupported_type_article(self):
         """special case in unsupported type because we do know what it is"""
         activity = self.create_json
         activity["object"] = {
@@ -298,7 +283,7 @@ class InboxCreate(TestCase):
         # just observe how it doesn't throw an error
         views.inbox.activity_task(activity)
 
-    def test_create_unsupported_type_unknown(self, *_):
+    def test_create_unsupported_type_unknown(self):
         """Something truly unexpected should throw an error"""
         activity = self.create_json
         activity["object"] = {
@@ -309,7 +294,7 @@ class InboxCreate(TestCase):
         with self.assertRaises(ActivitySerializerError):
             views.inbox.activity_task(activity)
 
-    def test_create_unknown_type(self, *_):
+    def test_create_unknown_type(self):
         """ignore activities we know we've never heard of"""
         activity = self.create_json
         activity["object"] = {

--- a/bookwyrm/tests/views/inbox/test_inbox_delete.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_delete.py
@@ -14,36 +14,29 @@ class InboxActivities(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.local_user.remote_id = "https://example.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            cls.status = models.Status.objects.create(
-                user=cls.remote_user,
-                content="Test status",
-                remote_id="https://example.com/status/1",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
+        cls.status = models.Status.objects.create(
+            user=cls.remote_user,
+            content="Test status",
+            remote_id="https://example.com/status/1",
+        )
 
     def test_delete_status(self):
         """remove a status"""
@@ -97,9 +90,7 @@ class InboxActivities(TestCase):
         self.assertEqual(models.Notification.objects.count(), 1)
         self.assertEqual(models.Notification.objects.get(), notif)
 
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    @patch("bookwyrm.activitystreams.remove_status_task.delay")
-    def test_delete_user(self, *_):
+    def test_delete_user(self):
         """delete a user"""
         self.assertTrue(models.User.objects.get(username="rat@example.com").is_active)
         activity = {

--- a/bookwyrm/tests/views/inbox/test_inbox_follow.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_follow.py
@@ -14,30 +14,24 @@ class InboxRelationships(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.local_user.remote_id = "https://example.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
     def test_follow(self):
         """remote user wants to follow local user"""
@@ -79,9 +73,7 @@ class InboxRelationships(TestCase):
             "actor": "https://example.com/users/rat",
             "object": "https://example.com/user/mouse",
         }
-
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.inbox.activity_task(activity)
+        views.inbox.activity_task(activity)
 
         # the follow relationship should exist
         follow = models.UserFollows.objects.get(user_object=self.local_user)
@@ -113,9 +105,7 @@ class InboxRelationships(TestCase):
         self.local_user.save(
             broadcast=False, update_fields=["manually_approves_followers"]
         )
-
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.inbox.activity_task(activity)
+        views.inbox.activity_task(activity)
 
         # notification created
         notification = models.Notification.objects.get()
@@ -137,10 +127,9 @@ class InboxRelationships(TestCase):
         self.local_user.save(
             broadcast=False, update_fields=["manually_approves_followers"]
         )
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            request = models.UserFollowRequest.objects.create(
-                user_subject=self.remote_user, user_object=self.local_user
-            )
+        request = models.UserFollowRequest.objects.create(
+            user_subject=self.remote_user, user_object=self.local_user
+        )
         self.assertTrue(self.local_user.follower_requests.exists())
 
         activity = {
@@ -165,10 +154,9 @@ class InboxRelationships(TestCase):
 
     def test_unfollow(self):
         """remove a relationship"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            rel = models.UserFollows.objects.create(
-                user_subject=self.remote_user, user_object=self.local_user
-            )
+        rel = models.UserFollows.objects.create(
+            user_subject=self.remote_user, user_object=self.local_user
+        )
         activity = {
             "type": "Undo",
             "id": "bleh",
@@ -188,14 +176,11 @@ class InboxRelationships(TestCase):
         views.inbox.activity_task(activity)
         self.assertIsNone(self.local_user.followers.first())
 
-    @patch("bookwyrm.activitystreams.add_user_statuses_task.delay")
-    @patch("bookwyrm.lists_stream.add_user_lists_task.delay")
-    def test_follow_accept(self, *_):
+    def test_follow_accept(self):
         """a remote user approved a follow request from local"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            rel = models.UserFollowRequest.objects.create(
-                user_subject=self.local_user, user_object=self.remote_user
-            )
+        rel = models.UserFollowRequest.objects.create(
+            user_subject=self.local_user, user_object=self.remote_user
+        )
         activity = {
             "@context": "https://www.w3.org/ns/activitystreams",
             "id": "https://example.com/users/rat/follows/123#accepts",
@@ -223,10 +208,9 @@ class InboxRelationships(TestCase):
 
     def test_follow_reject(self):
         """turn down a follow request"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            rel = models.UserFollowRequest.objects.create(
-                user_subject=self.local_user, user_object=self.remote_user
-            )
+        rel = models.UserFollowRequest.objects.create(
+            user_subject=self.local_user, user_object=self.remote_user
+        )
         activity = {
             "@context": "https://www.w3.org/ns/activitystreams",
             "id": "https://example.com/users/rat/follows/123#accepts",

--- a/bookwyrm/tests/views/inbox/test_inbox_like.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_like.py
@@ -1,7 +1,5 @@
 """tests incoming activities"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import models, views
@@ -13,40 +11,29 @@ class InboxActivities(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.local_user.remote_id = "https://example.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_status_task.delay"),
-        ):
-            cls.status = models.Status.objects.create(
-                user=cls.local_user,
-                content="Test status",
-                remote_id="https://example.com/status/1",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
+        cls.status = models.Status.objects.create(
+            user=cls.local_user,
+            content="Test status",
+            remote_id="https://example.com/status/1",
+        )
 
     def setUp(self):
         """individual test setup"""

--- a/bookwyrm/tests/views/inbox/test_inbox_remove.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_remove.py
@@ -1,7 +1,5 @@
 """tests incoming activities"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 
 from bookwyrm import models, views
@@ -13,31 +11,24 @@ class InboxRemove(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.local_user.remote_id = "https://example.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
-
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.work = models.Work.objects.create(title="work title")
         cls.book = models.Edition.objects.create(
             title="Test",
@@ -76,20 +67,16 @@ class InboxRemove(TestCase):
 
     def test_handle_remove_book_from_list(self):
         """listing a book"""
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            booklist = models.List.objects.create(
-                name="test list",
-                user=self.local_user,
-            )
-            listitem = models.ListItem.objects.create(
-                user=self.local_user,
-                book=self.book,
-                book_list=booklist,
-                order=1,
-            )
+        booklist = models.List.objects.create(
+            name="test list",
+            user=self.local_user,
+        )
+        listitem = models.ListItem.objects.create(
+            user=self.local_user,
+            book=self.book,
+            book_list=booklist,
+            order=1,
+        )
         self.assertEqual(booklist.books.count(), 1)
 
         activity = {

--- a/bookwyrm/tests/views/inbox/test_inbox_update.py
+++ b/bookwyrm/tests/views/inbox/test_inbox_update.py
@@ -15,30 +15,24 @@ class InboxUpdate(TestCase):
     @classmethod
     def setUpTestData(cls):
         """basic user and book data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+        )
         cls.local_user.remote_id = "https://example.com/user/mouse"
         cls.local_user.save(broadcast=False, update_fields=["remote_id"])
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -53,13 +47,9 @@ class InboxUpdate(TestCase):
 
     def test_update_list(self):
         """a new list"""
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            book_list = models.List.objects.create(
-                name="hi", remote_id="https://example.com/list/22", user=self.local_user
-            )
+        book_list = models.List.objects.create(
+            name="hi", remote_id="https://example.com/list/22", user=self.local_user
+        )
         activity = self.update_json
         activity["object"] = {
             "id": "https://example.com/list/22",
@@ -75,18 +65,14 @@ class InboxUpdate(TestCase):
             "curation": "curated",
             "@context": "https://www.w3.org/ns/activitystreams",
         }
-        with patch("bookwyrm.lists_stream.remove_list_task.delay"):
-            views.inbox.activity_task(activity)
+        views.inbox.activity_task(activity)
         book_list.refresh_from_db()
         self.assertEqual(book_list.name, "Test List")
         self.assertEqual(book_list.curation, "curated")
         self.assertEqual(book_list.description, "summary text")
         self.assertEqual(book_list.remote_id, "https://example.com/list/22")
 
-    @patch("bookwyrm.suggested_users.rerank_user_task.delay")
-    @patch("bookwyrm.activitystreams.add_user_statuses_task.delay")
-    @patch("bookwyrm.lists_stream.add_user_lists_task.delay")
-    def test_update_user(self, *_):
+    def test_update_user(self):
         """update an existing user"""
         models.UserFollows.objects.create(
             user_subject=self.local_user,
@@ -139,17 +125,16 @@ class InboxUpdate(TestCase):
         del bookdata["authors"]
         self.assertEqual(book.title, "Test Book")
 
-        with patch("bookwyrm.activitypub.base_activity.set_related_field.delay"):
-            views.inbox.activity_task(
-                {
-                    "type": "Update",
-                    "to": [],
-                    "cc": [],
-                    "actor": "hi",
-                    "id": "sdkjf",
-                    "object": bookdata,
-                }
-            )
+        views.inbox.activity_task(
+            {
+                "type": "Update",
+                "to": [],
+                "cc": [],
+                "actor": "hi",
+                "id": "sdkjf",
+                "object": bookdata,
+            }
+        )
         book = models.Edition.objects.get(id=book.id)
         self.assertEqual(book.title, "Piranesi")
         self.assertEqual(book.last_edited_by, self.remote_user)
@@ -206,23 +191,20 @@ class InboxUpdate(TestCase):
 
         del bookdata["authors"]
         self.assertEqual(book.title, "Test Book")
-        with patch("bookwyrm.activitypub.base_activity.set_related_field.delay"):
-            views.inbox.activity_task(
-                {
-                    "type": "Update",
-                    "to": [],
-                    "cc": [],
-                    "actor": "hi",
-                    "id": "sdkjf",
-                    "object": bookdata,
-                }
-            )
+        views.inbox.activity_task(
+            {
+                "type": "Update",
+                "to": [],
+                "cc": [],
+                "actor": "hi",
+                "id": "sdkjf",
+                "object": bookdata,
+            }
+        )
         book = models.Work.objects.get(id=book.id)
         self.assertEqual(book.title, "Piranesi")
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_update_status(self, *_):
+    def test_update_status(self):
         """edit a status"""
         status = models.Status.objects.create(user=self.remote_user, content="hi")
 
@@ -234,8 +216,7 @@ class InboxUpdate(TestCase):
         activity = self.update_json
         activity["object"] = status_data
 
-        with patch("bookwyrm.activitypub.base_activity.set_related_field.delay"):
-            views.inbox.activity_task(activity)
+        views.inbox.activity_task(activity)
 
         status.refresh_from_db()
         self.assertEqual(status.content, "test content in note")

--- a/bookwyrm/tests/views/landing/test_invite.py
+++ b/bookwyrm/tests/views/landing/test_invite.py
@@ -18,18 +18,13 @@ class InviteViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """individual test setup"""

--- a/bookwyrm/tests/views/landing/test_landing.py
+++ b/bookwyrm/tests/views/landing/test_landing.py
@@ -18,18 +18,13 @@ class LandingViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -37,13 +32,15 @@ class LandingViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    @patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions")
-    def test_home_page(self, _):
+    def test_home_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Home.as_view()
         request = self.factory.get("")
         request.user = self.local_user
-        with patch("bookwyrm.activitystreams.ActivityStream.get_activity_stream"):
+        with (
+            patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions"),
+            patch("bookwyrm.activitystreams.ActivityStream.get_activity_stream"),
+        ):
             result = view(request)
         self.assertEqual(result.status_code, 200)
         validate_html(result.render())

--- a/bookwyrm/tests/views/landing/test_login.py
+++ b/bookwyrm/tests/views/landing/test_login.py
@@ -16,42 +16,35 @@ from bookwyrm.tests.validate_html import validate_html
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class LoginViews(TestCase):
     """login and password management"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@your.domain.here",
-                "mouse@mouse.com",
-                "password",
-                local=True,
-                localname="mouse",
-                two_factor_auth=False,
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@your.domain.here",
-                "rat@rat.com",
-                "password",
-                local=True,
-                localname="rat",
-            )
-            cls.badger = models.User.objects.create_user(
-                "badger@your.domain.here",
-                "badger@badger.com",
-                "password",
-                local=True,
-                localname="badger",
-                two_factor_auth=True,
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@your.domain.here",
+            "mouse@mouse.com",
+            "password",
+            local=True,
+            localname="mouse",
+            two_factor_auth=False,
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@your.domain.here",
+            "rat@rat.com",
+            "password",
+            local=True,
+            localname="rat",
+        )
+        cls.badger = models.User.objects.create_user(
+            "badger@your.domain.here",
+            "badger@badger.com",
+            "password",
+            local=True,
+            localname="badger",
+            two_factor_auth=True,
+        )
         site = models.SiteSettings.get()
         site.require_confirm_email = False
         site.save()
@@ -62,7 +55,7 @@ class LoginViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    def test_login_get(self, *_):
+    def test_login_get(self):
         """there are so many views, this just makes sure it LOADS"""
         login = views.Login.as_view()
         request = self.factory.get("")
@@ -78,7 +71,7 @@ class LoginViews(TestCase):
         self.assertEqual(result.url, "/")
         self.assertEqual(result.status_code, 302)
 
-    def test_login_post_localname(self, *_):
+    def test_login_post_localname(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Login.as_view()
         form = forms.LoginForm()
@@ -96,7 +89,7 @@ class LoginViews(TestCase):
         self.assertEqual(result.url, "/")
         self.assertEqual(result.status_code, 302)
 
-    def test_login_post_username(self, *_):
+    def test_login_post_username(self):
         """valid login where the user provides their user@domain.com username"""
         view = views.Login.as_view()
         form = forms.LoginForm()
@@ -114,7 +107,7 @@ class LoginViews(TestCase):
         self.assertEqual(result.url, "/")
         self.assertEqual(result.status_code, 302)
 
-    def test_login_post_email(self, *_):
+    def test_login_post_email(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Login.as_view()
         form = forms.LoginForm()
@@ -132,7 +125,7 @@ class LoginViews(TestCase):
         self.assertEqual(result.url, "/")
         self.assertEqual(result.status_code, 302)
 
-    def test_login_post_invalid_credentials(self, *_):
+    def test_login_post_invalid_credentials(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Login.as_view()
         form = forms.LoginForm()
@@ -154,7 +147,7 @@ class LoginViews(TestCase):
             "Username or password are incorrect",
         )
 
-    def test_login_post_no_2fa_set(self, *_):
+    def test_login_post_no_2fa_set(self):
         """test user with 2FA null value is redirected to 2FA prompt page"""
         view = views.Login.as_view()
         form = forms.LoginForm()
@@ -172,7 +165,7 @@ class LoginViews(TestCase):
         self.assertEqual(result.url, "/2fa-prompt")
         self.assertEqual(result.status_code, 302)
 
-    def test_login_post_with_2fa(self, *_):
+    def test_login_post_with_2fa(self):
         """test user with 2FA turned on is redirected to 2FA login page"""
         view = views.Login.as_view()
         form = forms.LoginForm()

--- a/bookwyrm/tests/views/landing/test_password.py
+++ b/bookwyrm/tests/views/landing/test_password.py
@@ -20,18 +20,13 @@ class PasswordViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -61,8 +56,7 @@ class PasswordViews(TestCase):
 
         request = self.factory.post("", {"email": "mouse@mouse.com"})
         request.user = self.anonymous_user
-        with patch("bookwyrm.emailing.send_email.delay"):
-            resp = view(request)
+        resp = view(request)
         validate_html(resp.render())
 
         self.assertEqual(models.PasswordReset.objects.get().user, self.local_user)

--- a/bookwyrm/tests/views/landing/test_register.py
+++ b/bookwyrm/tests/views/landing/test_register.py
@@ -14,27 +14,19 @@ from bookwyrm.settings import DOMAIN
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.populate_lists_task.delay")
 class RegisterViews(TestCase):
     """login and password management"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@your.domain.here",
-                "mouse@mouse.com",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@your.domain.here",
+            "mouse@mouse.com",
+            "password",
+            local=True,
+            localname="mouse",
+        )
         cls.settings = models.SiteSettings.get()
         cls.settings.require_confirm_email = False
         cls.settings.allow_registration = True
@@ -46,14 +38,14 @@ class RegisterViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    def test_get_redirect(self, *_):
+    def test_get_redirect(self):
         """there's no dedicated registration page"""
         view = views.Register.as_view()
         request = self.factory.get("register/")
         response = view(request)
         self.assertEqual(response.status_code, 302)
 
-    def test_register(self, *_):
+    def test_register(self):
         """create a user"""
         view = views.Register.as_view()
         self.assertEqual(models.User.objects.count(), 1)
@@ -76,8 +68,7 @@ class RegisterViews(TestCase):
         self.assertEqual(nutria.local, True)
         self.assertEqual(nutria.preferred_timezone, "Europe/Berlin")
 
-    @patch("bookwyrm.emailing.send_email.delay")
-    def test_register_email_confirm(self, *_):
+    def test_register_email_confirm(self):
         """create a user"""
         self.settings.require_confirm_email = True
         self.settings.save()
@@ -103,7 +94,7 @@ class RegisterViews(TestCase):
         self.assertEqual(nutria.deactivation_reason, "pending")
         self.assertIsNotNone(nutria.confirmation_code)
 
-    def test_register_trailing_space(self, *_):
+    def test_register_trailing_space(self):
         """django handles this so weirdly"""
         view = views.Register.as_view()
         request = self.factory.post(
@@ -119,7 +110,7 @@ class RegisterViews(TestCase):
         self.assertEqual(nutria.localname, "nutria")
         self.assertEqual(nutria.local, True)
 
-    def test_register_invalid_email(self, *_):
+    def test_register_invalid_email(self):
         """gotta have an email"""
         view = views.Register.as_view()
         self.assertEqual(models.User.objects.count(), 1)
@@ -130,7 +121,7 @@ class RegisterViews(TestCase):
         self.assertEqual(models.User.objects.count(), 1)
         validate_html(response.render())
 
-    def test_register_invalid_password(self, *_):
+    def test_register_invalid_password(self):
         """gotta have an email"""
         view = views.Register.as_view()
         self.assertEqual(models.User.objects.count(), 1)
@@ -141,7 +132,7 @@ class RegisterViews(TestCase):
         self.assertEqual(models.User.objects.count(), 1)
         validate_html(response.render())
 
-    def test_register_error_and_invite(self, *_):
+    def test_register_error_and_invite(self):
         """redirect to the invite page"""
         view = views.Register.as_view()
         self.settings.allow_registration = False
@@ -165,7 +156,7 @@ class RegisterViews(TestCase):
         response = view(request)
         validate_html(response.render())
 
-    def test_register_username_in_use(self, *_):
+    def test_register_username_in_use(self):
         """that username is taken"""
         view = views.Register.as_view()
         self.assertEqual(models.User.objects.count(), 1)
@@ -177,7 +168,7 @@ class RegisterViews(TestCase):
         self.assertEqual(models.User.objects.count(), 1)
         validate_html(response.render())
 
-    def test_register_invalid_username(self, *_):
+    def test_register_invalid_username(self):
         """gotta have an email"""
         view = views.Register.as_view()
         self.assertEqual(models.User.objects.count(), 1)
@@ -205,7 +196,7 @@ class RegisterViews(TestCase):
         self.assertEqual(models.User.objects.count(), 1)
         validate_html(response.render())
 
-    def test_register_default_preferred_timezone(self, *_):
+    def test_register_default_preferred_timezone(self):
         """invalid preferred timezone strings should just default to UTC"""
         view = views.Register.as_view()
         self.assertEqual(models.User.objects.count(), 1)
@@ -257,7 +248,7 @@ class RegisterViews(TestCase):
         nutria = models.User.objects.last()
         self.assertEqual(nutria.preferred_timezone, "UTC")
 
-    def test_register_closed_instance(self, *_):
+    def test_register_closed_instance(self):
         """you can't just register"""
         view = views.Register.as_view()
         self.settings.allow_registration = False
@@ -269,7 +260,7 @@ class RegisterViews(TestCase):
         with self.assertRaises(PermissionDenied):
             view(request)
 
-    def test_register_blocked_domain(self, *_):
+    def test_register_blocked_domain(self):
         """you can't register with a blocked domain"""
         view = views.Register.as_view()
         models.EmailBlocklist.objects.create(domain="gmail.com")
@@ -293,7 +284,7 @@ class RegisterViews(TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertTrue(models.User.objects.filter(email="aa@bleep.com").exists())
 
-    def test_register_invite(self, *_):
+    def test_register_invite(self):
         """you can't just register"""
         view = views.Register.as_view()
         self.settings.allow_registration = False
@@ -346,7 +337,7 @@ class RegisterViews(TestCase):
             response = view(request)
         self.assertEqual(models.User.objects.count(), 2)
 
-    def test_confirm_email_code_get(self, *_):
+    def test_confirm_email_code_get(self):
         """there are so many views, this just makes sure it LOADS"""
         self.settings.require_confirm_email = True
         self.settings.save()
@@ -381,7 +372,7 @@ class RegisterViews(TestCase):
         self.assertEqual(result.url, "/")
         self.assertEqual(result.status_code, 302)
 
-    def test_confirm_email_code_get_invalid_code(self, *_):
+    def test_confirm_email_code_get_invalid_code(self):
         """there are so many views, this just makes sure it LOADS"""
         self.settings.require_confirm_email = True
         self.settings.save()
@@ -404,7 +395,7 @@ class RegisterViews(TestCase):
         self.assertFalse(self.local_user.is_active)
         self.assertEqual(self.local_user.deactivation_reason, "pending")
 
-    def test_confirm_email_get(self, *_):
+    def test_confirm_email_get(self):
         """there are so many views, this just makes sure it LOADS"""
         self.settings.require_confirm_email = True
         self.settings.save()
@@ -423,7 +414,7 @@ class RegisterViews(TestCase):
         self.assertEqual(result.url, "/")
         self.assertEqual(result.status_code, 302)
 
-    def test_confirm_email_post(self, *_):
+    def test_confirm_email_post(self):
         """send the email"""
         self.settings.require_confirm_email = True
         self.settings.save()
@@ -437,14 +428,14 @@ class RegisterViews(TestCase):
         result = view(request)
         validate_html(result.render())
 
-    def test_resend_link_get(self, *_):
+    def test_resend_link_get(self):
         """try again"""
         request = self.factory.get("")
         request.user = self.anonymous_user
         result = views.ResendConfirmEmail.as_view()(request)
         validate_html(result.render())
 
-    def test_resend_link_post(self, *_):
+    def test_resend_link_post(self):
         """try again"""
         request = self.factory.post("", {"email": "mouse@mouse.com"})
         request.user = self.anonymous_user

--- a/bookwyrm/tests/views/lists/test_curate.py
+++ b/bookwyrm/tests/views/lists/test_curate.py
@@ -18,31 +18,21 @@ class ListViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         work = models.Work.objects.create(title="Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
             remote_id="https://example.com/book/1",
             parent_work=work,
         )
-
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            cls.list = models.List.objects.create(name="Test List", user=cls.local_user)
+        cls.list = models.List.objects.create(name="Test List", user=cls.local_user)
 
     def setUp(self):
         """individual test setup"""
@@ -55,14 +45,13 @@ class ListViews(TestCase):
         view = views.Curate.as_view()
         request = self.factory.get("")
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=False,
-                order=1,
-            )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=False,
+            order=1,
+        )
 
         result = view(request, self.list.id)
         self.assertIsInstance(result, TemplateResponse)
@@ -76,15 +65,13 @@ class ListViews(TestCase):
     def test_curate_approve(self):
         """approve a pending item"""
         view = views.Curate.as_view()
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            pending = models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=False,
-                order=1,
-            )
-
+        pending = models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=False,
+            order=1,
+        )
         request = self.factory.post(
             "",
             {"item": pending.id, "approved": "true"},
@@ -110,15 +97,13 @@ class ListViews(TestCase):
     def test_curate_reject(self):
         """approve a pending item"""
         view = views.Curate.as_view()
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            pending = models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=False,
-                order=1,
-            )
-
+        pending = models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=False,
+            order=1,
+        )
         request = self.factory.post(
             "",
             {

--- a/bookwyrm/tests/views/lists/test_embed.py
+++ b/bookwyrm/tests/views/lists/test_embed.py
@@ -18,31 +18,21 @@ class ListViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         work = models.Work.objects.create(title="Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
             remote_id="https://example.com/book/1",
             parent_work=work,
         )
-
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            cls.list = models.List.objects.create(name="Test List", user=cls.local_user)
+        cls.list = models.List.objects.create(name="Test List", user=cls.local_user)
 
     def setUp(self):
         """individual test setup"""
@@ -55,14 +45,13 @@ class ListViews(TestCase):
         view = views.unsafe_embed_list
         request = self.factory.get("")
         request.user = self.anonymous_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=True,
-                order=1,
-            )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=True,
+            order=1,
+        )
 
         with patch("bookwyrm.views.list.list.is_api_request") as is_api:
             is_api.return_value = False
@@ -74,15 +63,13 @@ class ListViews(TestCase):
         view = views.unsafe_embed_list
         request = self.factory.get("")
         request.user = self.anonymous_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=True,
-                order=1,
-            )
-
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=True,
+            order=1,
+        )
         embed_key = str(self.list.embed_key.hex)
 
         with patch("bookwyrm.views.list.list.is_api_request") as is_api:

--- a/bookwyrm/tests/views/lists/test_list.py
+++ b/bookwyrm/tests/views/lists/test_list.py
@@ -20,27 +20,22 @@ class ListViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@rat.com",
-                "ratword",
-                local=True,
-                localname="rat",
-                remote_id="https://example.com/users/rat",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@rat.com",
+            "ratword",
+            local=True,
+            localname="rat",
+            remote_id="https://example.com/users/rat",
+        )
         work = models.Work.objects.create(title="Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -65,12 +60,7 @@ class ListViews(TestCase):
             remote_id="https://example.com/book/4",
             parent_work=work_four,
         )
-
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            cls.list = models.List.objects.create(name="Test List", user=cls.local_user)
+        cls.list = models.List.objects.create(name="Test List", user=cls.local_user)
 
     def setUp(self):
         """individual test setup"""
@@ -83,15 +73,14 @@ class ListViews(TestCase):
         view = views.List.as_view()
         request = self.factory.get("")
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=True,
-                notes="hello",
-                order=1,
-            )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=True,
+            notes="hello",
+            order=1,
+        )
 
         with patch("bookwyrm.views.list.list.is_api_request") as is_api:
             is_api.return_value = False
@@ -116,15 +105,14 @@ class ListViews(TestCase):
     def test_list_page_sorted(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.List.as_view()
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            for i, book in enumerate([self.book, self.book_two, self.book_three]):
-                models.ListItem.objects.create(
-                    book_list=self.list,
-                    user=self.local_user,
-                    book=book,
-                    approved=True,
-                    order=i + 1,
-                )
+        for i, book in enumerate([self.book, self.book_two, self.book_three]):
+            models.ListItem.objects.create(
+                book_list=self.list,
+                user=self.local_user,
+                book=book,
+                approved=True,
+                order=i + 1,
+            )
 
         request = self.factory.get("/?sort_by=order")
         request.user = self.local_user
@@ -178,15 +166,14 @@ class ListViews(TestCase):
     def test_list_page_logged_out(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.List.as_view()
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                notes="hi hello",
-                approved=True,
-                order=1,
-            )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            notes="hi hello",
+            approved=True,
+            order=1,
+        )
 
         request = self.factory.get("")
         request.user = self.anonymous_user
@@ -202,14 +189,13 @@ class ListViews(TestCase):
         view = views.List.as_view()
         request = self.factory.get("")
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=True,
-                order=1,
-            )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=True,
+            order=1,
+        )
 
         with patch("bookwyrm.views.list.list.is_api_request") as is_api:
             is_api.return_value = True
@@ -246,12 +232,9 @@ class ListViews(TestCase):
         )
         request.user = self.local_user
 
-        with (
-            patch(
-                "bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"
-            ) as mock,
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
+        with patch(
+            "bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"
+        ) as mock:
             result = view(request, self.list.id)
 
         self.assertEqual(mock.call_count, 1)
@@ -270,21 +253,20 @@ class ListViews(TestCase):
 
     def test_delete_list(self):
         """delete an entire list"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=True,
-                order=1,
-            )
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book_two,
-                approved=False,
-                order=2,
-            )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=True,
+            order=1,
+        )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book_two,
+            approved=False,
+            order=2,
+        )
         request = self.factory.post("")
         request.user = self.local_user
         with (
@@ -363,9 +345,8 @@ class ListViews(TestCase):
             },
         )
         request_two.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.add_book(request_one)
-            views.add_book(request_two)
+        views.add_book(request_one)
+        views.add_book(request_two)
 
         items = self.list.listitem_set.order_by("order").all()
         self.assertEqual(items[0].book, self.book)
@@ -408,10 +389,9 @@ class ListViews(TestCase):
         )
         request_three.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.add_book(request_one)
-            views.add_book(request_two)
-            views.add_book(request_three)
+        views.add_book(request_one)
+        views.add_book(request_two)
+        views.add_book(request_three)
 
         items = self.list.listitem_set.order_by("order").all()
         self.assertEqual(items[0].book, self.book)
@@ -423,8 +403,7 @@ class ListViews(TestCase):
 
         remove_request = self.factory.post("", {"item": items[1].id})
         remove_request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.remove_book(remove_request, self.list.id)
+        views.remove_book(remove_request, self.list.id)
         items = self.list.listitem_set.order_by("order").all()
         self.assertEqual(items[0].book, self.book)
         self.assertEqual(items[1].book, self.book_three)
@@ -446,22 +425,21 @@ class ListViews(TestCase):
             },
         )
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=True,
-                order=1,
-            )
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.rat,
-                book=self.book_two,
-                approved=False,
-                order=2,
-            )
-            views.add_book(request)
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=True,
+            order=1,
+        )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.rat,
+            book=self.book_two,
+            approved=False,
+            order=2,
+        )
+        views.add_book(request)
 
         items = self.list.listitem_set.order_by("order").all()
         self.assertEqual(items[0].book, self.book)
@@ -483,35 +461,34 @@ class ListViews(TestCase):
         its order should be at the end of the approved books and before the
         remaining pending books.
         """
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=True,
-                order=1,
-            )
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book_two,
-                approved=True,
-                order=2,
-            )
-            models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.rat,
-                book=self.book_three,
-                approved=False,
-                order=3,
-            )
-            to_be_approved = models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.rat,
-                book=self.book_four,
-                approved=False,
-                order=4,
-            )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=True,
+            order=1,
+        )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book_two,
+            approved=True,
+            order=2,
+        )
+        models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.rat,
+            book=self.book_three,
+            approved=False,
+            order=3,
+        )
+        to_be_approved = models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.rat,
+            book=self.book_four,
+            approved=False,
+            order=4,
+        )
 
         view = views.Curate.as_view()
         request = self.factory.post(
@@ -523,8 +500,7 @@ class ListViews(TestCase):
         )
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request, self.list.id)
+        view(request, self.list.id)
 
         items = self.list.listitem_set.order_by("order").all()
         self.assertEqual(items[0].book, self.book)
@@ -578,10 +554,9 @@ class ListViews(TestCase):
         )
         request_three.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.add_book(request_one)
-            views.add_book(request_two)
-            views.add_book(request_three)
+        views.add_book(request_one)
+        views.add_book(request_two)
+        views.add_book(request_three)
 
         items = self.list.listitem_set.order_by("order").all()
         self.assertEqual(items[0].book, self.book)
@@ -593,8 +568,7 @@ class ListViews(TestCase):
 
         set_position_request = self.factory.post("", {"position": 1})
         set_position_request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.set_book_position(set_position_request, items[2].id)
+        views.set_book_position(set_position_request, items[2].id)
         items = self.list.listitem_set.order_by("order").all()
         self.assertEqual(items[0].book, self.book_three)
         self.assertEqual(items[1].book, self.book)
@@ -713,29 +687,25 @@ class ListViews(TestCase):
 
     def test_remove_book(self):
         """take an item off a list"""
-
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            item = models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                order=1,
-            )
+        item = models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            order=1,
+        )
         self.assertTrue(self.list.listitem_set.exists())
 
         request = self.factory.post("", {"item": item.id})
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.remove_book(request, self.list.id)
+        views.remove_book(request, self.list.id)
         self.assertFalse(self.list.listitem_set.exists())
 
     def test_remove_book_unauthorized(self):
         """take an item off a list"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            item = models.ListItem.objects.create(
-                book_list=self.list, user=self.local_user, book=self.book, order=1
-            )
+        item = models.ListItem.objects.create(
+            book_list=self.list, user=self.local_user, book=self.book, order=1
+        )
         self.assertTrue(self.list.listitem_set.exists())
         request = self.factory.post("", {"item": item.id})
         request.user = self.rat

--- a/bookwyrm/tests/views/lists/test_list_item.py
+++ b/bookwyrm/tests/views/lists/test_list_item.py
@@ -14,30 +14,21 @@ class ListItemViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         work = models.Work.objects.create(title="Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
             remote_id="https://example.com/book/1",
             parent_work=work,
         )
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            cls.list = models.List.objects.create(name="Test List", user=cls.local_user)
+        cls.list = models.List.objects.create(name="Test List", user=cls.local_user)
 
     def setUp(self):
         """individual test setup"""
@@ -46,14 +37,13 @@ class ListItemViews(TestCase):
     def test_add_list_item_notes(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.ListItem.as_view()
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            item = models.ListItem.objects.create(
-                book_list=self.list,
-                user=self.local_user,
-                book=self.book,
-                approved=True,
-                order=1,
-            )
+        item = models.ListItem.objects.create(
+            book_list=self.list,
+            user=self.local_user,
+            book=self.book,
+            approved=True,
+            order=1,
+        )
         request = self.factory.post(
             "",
             {

--- a/bookwyrm/tests/views/lists/test_lists.py
+++ b/bookwyrm/tests/views/lists/test_lists.py
@@ -19,22 +19,17 @@ class ListViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-            cls.another_user = models.User.objects.create_user(
-                "rat@local.com", "rat@rat.com", "ratword", local=True, localname="rat"
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.another_user = models.User.objects.create_user(
+            "rat@local.com", "rat@rat.com", "ratword", local=True, localname="rat"
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -42,23 +37,19 @@ class ListViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    @patch("bookwyrm.lists_stream.ListsStream.get_list_stream")
-    def test_lists_page(self, _):
+    def test_lists_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Lists.as_view()
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.add_list_task.delay"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            models.List.objects.create(name="Public list", user=self.local_user)
-            models.List.objects.create(
-                name="Private list", privacy="direct", user=self.local_user
-            )
+        models.List.objects.create(name="Public list", user=self.local_user)
+        models.List.objects.create(
+            name="Private list", privacy="direct", user=self.local_user
+        )
         request = self.factory.get("")
         request.user = self.local_user
 
-        result = view(request)
+        with patch("bookwyrm.lists_stream.ListsStream.get_list_stream"):
+            result = view(request)
+
         self.assertIsInstance(result, TemplateResponse)
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
@@ -73,16 +64,10 @@ class ListViews(TestCase):
     def test_saved_lists_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.SavedLists.as_view()
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            booklist = models.List.objects.create(
-                name="Public list", user=self.local_user
-            )
-            models.List.objects.create(
-                name="Private list", privacy="direct", user=self.local_user
-            )
+        booklist = models.List.objects.create(name="Public list", user=self.local_user)
+        models.List.objects.create(
+            name="Private list", privacy="direct", user=self.local_user
+        )
         self.local_user.saved_lists.add(booklist)
         request = self.factory.get("")
         request.user = self.local_user
@@ -96,14 +81,10 @@ class ListViews(TestCase):
     def test_saved_lists_page_empty(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.SavedLists.as_view()
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            models.List.objects.create(name="Public list", user=self.local_user)
-            models.List.objects.create(
-                name="Private list", privacy="direct", user=self.local_user
-            )
+        models.List.objects.create(name="Public list", user=self.local_user)
+        models.List.objects.create(
+            name="Private list", privacy="direct", user=self.local_user
+        )
         request = self.factory.get("")
         request.user = self.local_user
 
@@ -125,14 +106,10 @@ class ListViews(TestCase):
     def test_user_lists_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.UserLists.as_view()
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            models.List.objects.create(name="Public list", user=self.local_user)
-            models.List.objects.create(
-                name="Private list", privacy="direct", user=self.local_user
-            )
+        models.List.objects.create(name="Public list", user=self.local_user)
+        models.List.objects.create(
+            name="Private list", privacy="direct", user=self.local_user
+        )
         request = self.factory.get("")
         request.user = self.local_user
 
@@ -144,14 +121,10 @@ class ListViews(TestCase):
     def test_user_lists_page_logged_out(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.UserLists.as_view()
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            models.List.objects.create(name="Public list", user=self.local_user)
-            models.List.objects.create(
-                name="Private list", privacy="direct", user=self.local_user
-            )
+        models.List.objects.create(name="Public list", user=self.local_user)
+        models.List.objects.create(
+            name="Private list", privacy="direct", user=self.local_user
+        )
         request = self.factory.get("")
         request.user = self.anonymous_user
 
@@ -174,12 +147,9 @@ class ListViews(TestCase):
             },
         )
         request.user = self.local_user
-        with (
-            patch(
-                "bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"
-            ) as mock,
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
+        with patch(
+            "bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"
+        ) as mock:
             result = view(request)
 
         self.assertEqual(mock.call_count, 1)

--- a/bookwyrm/tests/views/preferences/test_block.py
+++ b/bookwyrm/tests/views/preferences/test_block.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.template.response import TemplateResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -10,41 +8,34 @@ from bookwyrm import models, views
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class BlockViews(TestCase):
     """view user and edit profile"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
     def setUp(self):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_block_get(self, _):
+    def test_block_get(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Block.as_view()
         request = self.factory.get("")
@@ -54,7 +45,7 @@ class BlockViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_block_post(self, _):
+    def test_block_post(self):
         """create a "block" database entry from an activity"""
         view = views.Block.as_view()
         self.local_user.followers.add(self.remote_user)
@@ -66,11 +57,9 @@ class BlockViews(TestCase):
 
         request = self.factory.post("")
         request.user = self.local_user
-        with (
-            patch("bookwyrm.activitystreams.remove_user_statuses_task.delay"),
-            patch("bookwyrm.lists_stream.remove_user_lists_task.delay"),
-        ):
-            view(request, self.remote_user.id)
+
+        view(request, self.remote_user.id)
+
         block = models.UserBlocks.objects.get()
         self.assertEqual(block.user_subject, self.local_user)
         self.assertEqual(block.user_object, self.remote_user)
@@ -78,16 +67,11 @@ class BlockViews(TestCase):
         self.assertFalse(models.UserFollows.objects.exists())
         self.assertFalse(models.UserFollowRequest.objects.exists())
 
-    def test_unblock(self, _):
+    def test_unblock(self):
         """undo a block"""
         self.local_user.blocks.add(self.remote_user)
         request = self.factory.post("")
         request.user = self.local_user
 
-        with (
-            patch("bookwyrm.activitystreams.add_user_statuses_task.delay"),
-            patch("bookwyrm.lists_stream.add_user_lists_task.delay"),
-        ):
-            views.unblock(request, self.remote_user.id)
-
+        views.unblock(request, self.remote_user.id)
         self.assertFalse(models.UserBlocks.objects.exists())

--- a/bookwyrm/tests/views/preferences/test_change_password.py
+++ b/bookwyrm/tests/views/preferences/test_change_password.py
@@ -16,18 +16,13 @@ class ChangePasswordViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """individual test setup"""

--- a/bookwyrm/tests/views/preferences/test_delete_user.py
+++ b/bookwyrm/tests/views/preferences/test_delete_user.py
@@ -13,45 +13,35 @@ from bookwyrm import forms, models, views
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.suggested_users.remove_user_task.delay")
 class DeleteUserViews(TestCase):
     """view user and edit profile"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@your.domain.here",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@your.domain.here",
-                "rat@rat.rat",
-                "password",
-                local=True,
-                localname="rat",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@your.domain.here",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@your.domain.here",
+            "rat@rat.rat",
+            "password",
+            local=True,
+            localname="rat",
+        )
 
-            cls.book = models.Edition.objects.create(
-                title="test", parent_work=models.Work.objects.create(title="test work")
-            )
-            with (
-                patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-                patch("bookwyrm.activitystreams.add_book_statuses_task.delay"),
-            ):
-                models.ShelfBook.objects.create(
-                    book=cls.book,
-                    user=cls.local_user,
-                    shelf=cls.local_user.shelf_set.first(),
-                )
+        cls.book = models.Edition.objects.create(
+            title="test", parent_work=models.Work.objects.create(title="test work")
+        )
+        models.ShelfBook.objects.create(
+            book=cls.book,
+            user=cls.local_user,
+            shelf=cls.local_user.shelf_set.first(),
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -59,7 +49,7 @@ class DeleteUserViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    def test_delete_user_page(self, _):
+    def test_delete_user_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.DeleteUser.as_view()
         request = self.factory.get("")
@@ -69,8 +59,7 @@ class DeleteUserViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task")
-    def test_delete_user(self, *_):
+    def test_delete_user(self):
         """use a form to update a user"""
         view = views.DeleteUser.as_view()
         request = self.factory.post("")
@@ -97,7 +86,7 @@ class DeleteUserViews(TestCase):
         self.assertFalse(self.local_user.has_usable_password())
         self.assertEqual(self.local_user.deactivation_reason, "self_deletion")
 
-    def test_deactivate_user(self, _):
+    def test_deactivate_user(self):
         """Impermanent deletion"""
         self.assertTrue(self.local_user.is_active)
         view = views.DeactivateUser.as_view()
@@ -114,7 +103,7 @@ class DeleteUserViews(TestCase):
         self.assertTrue(self.local_user.has_usable_password())
         self.assertEqual(self.local_user.deactivation_reason, "self_deactivation")
 
-    def test_reactivate_user_get(self, _):
+    def test_reactivate_user_get(self):
         """Reactication page"""
         view = views.ReactivateUser.as_view()
         request = self.factory.get("")
@@ -125,7 +114,7 @@ class DeleteUserViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_reactivate_user_post(self, _):
+    def test_reactivate_user_post(self):
         """Reactivate action"""
         self.local_user.deactivate()
         self.local_user.refresh_from_db()
@@ -140,14 +129,13 @@ class DeleteUserViews(TestCase):
         middleware.process_request(request)
         request.session.save()
 
-        with patch("bookwyrm.views.preferences.delete_user.login"):
-            view(request)
+        view(request)
 
         self.local_user.refresh_from_db()
         self.assertTrue(self.local_user.is_active)
         self.assertIsNone(self.local_user.deactivation_reason)
 
-    def test_reactivate_user_post_disallowed(self, _):
+    def test_reactivate_user_post_disallowed(self):
         """Reactivate action under the wrong circumstances"""
         self.local_user.is_active = False
         self.local_user.save(broadcast=False)
@@ -162,8 +150,7 @@ class DeleteUserViews(TestCase):
         middleware.process_request(request)
         request.session.save()
 
-        with patch("bookwyrm.views.preferences.delete_user.login"):
-            view(request)
+        view(request)
 
         self.local_user.refresh_from_db()
         self.assertFalse(self.local_user.is_active)

--- a/bookwyrm/tests/views/preferences/test_edit_user.py
+++ b/bookwyrm/tests/views/preferences/test_edit_user.py
@@ -15,41 +15,31 @@ from bookwyrm import forms, models, views
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.suggested_users.remove_user_task.delay")
 class EditUserViews(TestCase):
     """view user and edit profile"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@local.com", "rat@rat.rat", "password", local=True, localname="rat"
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@local.com", "rat@rat.rat", "password", local=True, localname="rat"
+        )
 
-            cls.book = models.Edition.objects.create(
-                title="test", parent_work=models.Work.objects.create(title="test work")
-            )
-            with (
-                patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-                patch("bookwyrm.activitystreams.add_book_statuses_task.delay"),
-            ):
-                models.ShelfBook.objects.create(
-                    book=cls.book,
-                    user=cls.local_user,
-                    shelf=cls.local_user.shelf_set.first(),
-                )
+        cls.book = models.Edition.objects.create(
+            title="test", parent_work=models.Work.objects.create(title="test work")
+        )
+        models.ShelfBook.objects.create(
+            book=cls.book,
+            user=cls.local_user,
+            shelf=cls.local_user.shelf_set.first(),
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -57,7 +47,7 @@ class EditUserViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    def test_edit_user_page(self, _):
+    def test_edit_user_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.EditUser.as_view()
         request = self.factory.get("")
@@ -67,7 +57,7 @@ class EditUserViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_edit_user(self, _):
+    def test_edit_user(self):
         """use a form to update a user"""
         view = views.EditUser.as_view()
         form = forms.EditUserForm(instance=self.local_user)
@@ -87,7 +77,7 @@ class EditUserViews(TestCase):
         self.assertEqual(self.local_user.name, "New Name")
         self.assertEqual(self.local_user.email, "wow@email.com")
 
-    def test_edit_user_avatar(self, _):
+    def test_edit_user_avatar(self):
         """use a form to update a user"""
         view = views.EditUser.as_view()
         form = forms.EditUserForm(instance=self.local_user)
@@ -116,7 +106,7 @@ class EditUserViews(TestCase):
         self.assertEqual(self.local_user.avatar.width, 120)
         self.assertEqual(self.local_user.avatar.height, 120)
 
-    def test_crop_avatar(self, _):
+    def test_crop_avatar(self):
         """reduce that image size"""
         image_path = pathlib.Path(__file__).parent.joinpath(
             "../../../static/images/no_cover.jpg"

--- a/bookwyrm/tests/views/preferences/test_export.py
+++ b/bookwyrm/tests/views/preferences/test_export.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -10,29 +8,20 @@ from bookwyrm import models, views
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class ExportViews(TestCase):
     """viewing and creating statuses"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Test Book",
@@ -47,14 +36,14 @@ class ExportViews(TestCase):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def tst_export_get(self, *_):
+    def tst_export_get(self):
         """request export"""
         request = self.factory.get("")
         request.user = self.local_user
         result = views.Export.as_view()(request)
         validate_html(result.render())
 
-    def test_export_file(self, *_):
+    def test_export_file(self):
         """simple export"""
         shelfbook = models.ShelfBook.objects.create(
             shelf=self.local_user.shelf_set.first(),

--- a/bookwyrm/tests/views/preferences/test_export_user.py
+++ b/bookwyrm/tests/views/preferences/test_export_user.py
@@ -1,7 +1,5 @@
 """test for user export app functionality"""
 
-from unittest.mock import patch
-
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -16,20 +14,16 @@ class ExportUserViews(TestCase):
     def setUp(self):
         self.site = models.SiteSettings.get()
         self.factory = RequestFactory()
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-        ):
-            self.local_user = models.User.objects.create_user(
-                "hugh@example.com",
-                "hugh@example.com",
-                "password",
-                local=True,
-                localname="Hugh",
-                summary="just a test account",
-                remote_id="https://example.com/users/hugh",
-                preferred_timezone="Australia/Broken_Hill",
-            )
+        self.local_user = models.User.objects.create_user(
+            "hugh@example.com",
+            "hugh@example.com",
+            "password",
+            local=True,
+            localname="Hugh",
+            summary="just a test account",
+            remote_id="https://example.com/users/hugh",
+            preferred_timezone="Australia/Broken_Hill",
+        )
 
     def test_export_user_get(self, *_):
         """request export"""
@@ -43,8 +37,8 @@ class ExportUserViews(TestCase):
 
         request = self.factory.post("")
         request.user = self.local_user
-        with patch("bookwyrm.models.bookwyrm_export_job.BookwyrmExportJob.start_job"):
-            export = views.ExportUser.as_view()(request)
+
+        export = views.ExportUser.as_view()(request)
         self.assertIsInstance(export, HttpResponse)
         self.assertEqual(export.status_code, 302)
 

--- a/bookwyrm/tests/views/preferences/test_move.py
+++ b/bookwyrm/tests/views/preferences/test_move.py
@@ -1,7 +1,6 @@
 """test move functionality"""
 
 import json
-from unittest.mock import patch
 import pathlib
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import TestCase
@@ -11,43 +10,27 @@ import responses
 from bookwyrm import forms, models, views
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.suggested_users.rerank_user_task.delay")
 class ViewsHelpers(TestCase):
     """viewing and creating statuses"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=True,
-                discoverable=True,
-                localname="rat",
-            )
-
-        with (
-            patch("bookwyrm.models.user.set_remote_server.delay"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
-        ):
-            cls.remote_user = models.User.objects.create_user(
-                "mouse@example.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=False,
-                remote_id="https://example.com/user/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=True,
+            discoverable=True,
+            localname="rat",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "mouse@example.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=False,
+            remote_id="https://example.com/user/mouse",
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -59,10 +42,7 @@ class ViewsHelpers(TestCase):
         del self.userdata["icon"]
 
     @responses.activate
-    @patch("bookwyrm.models.user.set_remote_server.delay")
-    @patch("bookwyrm.suggested_users.remove_user_task.delay")
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    def test_move_user_view(self, *_):
+    def test_move_user_view(self):
         """move user"""
 
         self.assertEqual(self.remote_user.remote_id, "https://example.com/user/mouse")
@@ -113,10 +93,9 @@ class ViewsHelpers(TestCase):
         middleware.process_request(request)
         request.session.save()
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request)
-            self.local_user.refresh_from_db()
+        view(request)
+        self.local_user.refresh_from_db()
 
-            self.assertEqual(self.local_user.also_known_as.first(), self.remote_user)
-            self.assertEqual(self.remote_user.also_known_as.first(), self.local_user)
-            self.assertEqual(self.local_user.moved_to, "https://example.com/user/mouse")
+        self.assertEqual(self.local_user.also_known_as.first(), self.remote_user)
+        self.assertEqual(self.remote_user.also_known_as.first(), self.local_user)
+        self.assertEqual(self.local_user.moved_to, "https://example.com/user/mouse")

--- a/bookwyrm/tests/views/preferences/test_security.py
+++ b/bookwyrm/tests/views/preferences/test_security.py
@@ -17,30 +17,23 @@ from bookwyrm import forms, models, views
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class TwoFactorViews(TestCase):
     """Two Factor Authentication management"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@your.domain.here",
-                "mouse@mouse.com",
-                "password",
-                local=True,
-                localname="mouse",
-                two_factor_auth=True,
-                otp_secret="UEWMVJHO23G5XLMVSOCL6TNTSSACJH2X",
-                hotp_secret="DRMNMOU7ZRKH5YPW7PADOEYUF7MRIH46",
-                hotp_count=0,
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@your.domain.here",
+            "mouse@mouse.com",
+            "password",
+            local=True,
+            localname="mouse",
+            two_factor_auth=True,
+            otp_secret="UEWMVJHO23G5XLMVSOCL6TNTSSACJH2X",
+            hotp_secret="DRMNMOU7ZRKH5YPW7PADOEYUF7MRIH46",
+            hotp_count=0,
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -48,7 +41,7 @@ class TwoFactorViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    def test_get_security_as_view(self, *_):
+    def test_get_security_as_view(self):
         """does the page load?"""
 
         view = views.UserSecurity.as_view()
@@ -62,7 +55,7 @@ class TwoFactorViews(TestCase):
         self.assertIsInstance(result, TemplateResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_get_security_logged_out(self, *_):
+    def test_get_security_logged_out(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.UserSecurity.as_view()
         request = self.factory.get("")
@@ -70,7 +63,7 @@ class TwoFactorViews(TestCase):
         result = view(request)
         self.assertEqual(result.status_code, 302)
 
-    def test_post_edit_2fa(self, *_):
+    def test_post_edit_2fa(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Edit2FA.as_view()
         form = forms.ConfirmPasswordForm()
@@ -78,12 +71,11 @@ class TwoFactorViews(TestCase):
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
-        with patch("bookwyrm.views.preferences.security.Edit2FA"):
-            result = view(request)
+        result = view(request)
         self.assertIsInstance(result, TemplateResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_post_confirm_2fa(self, *_):
+    def test_post_confirm_2fa(self):
         """check 2FA login works"""
         view = views.Confirm2FA.as_view()
         form = forms.Confirm2FAForm()
@@ -92,12 +84,11 @@ class TwoFactorViews(TestCase):
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
-        with patch("bookwyrm.views.preferences.security.Confirm2FA"):
-            result = view(request)
+        result = view(request)
         self.assertIsInstance(result, TemplateResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_get_disable_2fa(self, *_):
+    def test_get_disable_2fa(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Disable2FA.as_view()
         request = self.factory.get("")
@@ -106,18 +97,17 @@ class TwoFactorViews(TestCase):
         self.assertIsInstance(result, TemplateResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_post_disable_2fa(self, *_):
+    def test_post_disable_2fa(self):
         """check 2FA login works"""
         view = views.Disable2FA.as_view()
         request = self.factory.post("")
         request.user = self.local_user
 
-        with patch("bookwyrm.views.preferences.security.Disable2FA"):
-            result = view(request)
+        result = view(request)
         self.assertIsInstance(result, TemplateResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_get_login_with_2fa(self, *_):
+    def test_get_login_with_2fa(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.LoginWith2FA.as_view()
         request = self.factory.get("")
@@ -126,7 +116,7 @@ class TwoFactorViews(TestCase):
         self.assertIsInstance(result, TemplateResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_post_login_with_2fa(self, *_):
+    def test_post_login_with_2fa(self):
         """check 2FA login works"""
         view = views.LoginWith2FA.as_view()
         form = forms.Confirm2FAForm()
@@ -151,7 +141,7 @@ class TwoFactorViews(TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertTrue(request.user.is_authenticated)
 
-    def test_post_login_with_2fa_wrong_code(self, *_):
+    def test_post_login_with_2fa_wrong_code(self):
         """check 2FA login fails"""
         view = views.LoginWith2FA.as_view()
         form = forms.Confirm2FAForm()
@@ -165,15 +155,14 @@ class TwoFactorViews(TestCase):
         request.session["2fa_user"] = self.local_user.username
         request.session.save()
 
-        with patch("bookwyrm.views.preferences.security.LoginWith2FA"):
-            result = view(request)
+        result = view(request)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(
             result.context_data["form"]["otp"].errors[0],
             "Incorrect code",
         )
 
-    def test_post_login_with_2fa_expired(self, *_):
+    def test_post_login_with_2fa_expired(self):
         """check 2FA login fails"""
         view = views.LoginWith2FA.as_view()
         form = forms.Confirm2FAForm()
@@ -193,7 +182,7 @@ class TwoFactorViews(TestCase):
         self.assertEqual(result.url, "/")
         self.assertEqual(result.status_code, 302)
 
-    def test_get_generate_backup_codes(self, *_):
+    def test_get_generate_backup_codes(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.GenerateBackupCodes.as_view()
         request = self.factory.get("")
@@ -202,7 +191,7 @@ class TwoFactorViews(TestCase):
         self.assertIsInstance(result, TemplateResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_get_prompt_2fa(self, *_):
+    def test_get_prompt_2fa(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Prompt2FA.as_view()
         request = self.factory.get("")
@@ -211,7 +200,7 @@ class TwoFactorViews(TestCase):
         self.assertIsInstance(result, TemplateResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_logout_session(self, *_):
+    def test_logout_session(self):
         """does logout_session work?"""
 
         cache_session = SessionStore()

--- a/bookwyrm/tests/views/shelf/test_shelf.py
+++ b/bookwyrm/tests/views/shelf/test_shelf.py
@@ -12,41 +12,29 @@ from bookwyrm.activitypub import ActivitypubResponse
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.populate_lists_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.activitystreams.remove_book_statuses_task.delay")
 class ShelfViews(TestCase):
     """tag views"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
             remote_id="https://example.com/book/1",
             parent_work=cls.work,
         )
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            cls.shelf = models.Shelf.objects.create(
-                name="Test Shelf", identifier="test-shelf", user=cls.local_user
-            )
+        cls.shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=cls.local_user
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -54,7 +42,7 @@ class ShelfViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    def test_shelf_page_all_books(self, *_):
+    def test_shelf_page_all_books(self):
         """there are so many views, this just makes sure it LOADS"""
         models.ShelfBook.objects.create(
             book=self.book,
@@ -71,7 +59,7 @@ class ShelfViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_shelf_page_all_books_empty(self, *_):
+    def test_shelf_page_all_books_empty(self):
         """No books shelved"""
         view = views.Shelf.as_view()
         request = self.factory.get("")
@@ -83,7 +71,7 @@ class ShelfViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_shelf_page_all_books_avoid_duplicates(self, *_):
+    def test_shelf_page_all_books_avoid_duplicates(self):
         """Make sure books aren't showing up twice on the all shelves view"""
         models.ShelfBook.objects.create(
             book=self.book,
@@ -106,7 +94,7 @@ class ShelfViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_shelf_page_all_books_json(self, *_):
+    def test_shelf_page_all_books_json(self):
         """there is no json view here"""
         view = views.Shelf.as_view()
         request = self.factory.get("")
@@ -118,7 +106,7 @@ class ShelfViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_shelf_page_all_books_anonymous(self, *_):
+    def test_shelf_page_all_books_anonymous(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Shelf.as_view()
         request = self.factory.get("")
@@ -130,7 +118,7 @@ class ShelfViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_shelf_page_sorted(self, *_):
+    def test_shelf_page_sorted(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Shelf.as_view()
         shelf = self.local_user.shelf_set.first()
@@ -143,7 +131,7 @@ class ShelfViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_shelf_page(self, *_):
+    def test_shelf_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Shelf.as_view()
         shelf = self.local_user.shelf_set.first()
@@ -170,7 +158,7 @@ class ShelfViews(TestCase):
         self.assertIsInstance(result, ActivitypubResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_edit_shelf_privacy(self, *_):
+    def test_edit_shelf_privacy(self):
         """set name or privacy on shelf"""
         view = views.Shelf.as_view()
         shelf = self.local_user.shelf_set.get(identifier="to-read")
@@ -190,7 +178,7 @@ class ShelfViews(TestCase):
 
         self.assertEqual(shelf.privacy, "unlisted")
 
-    def test_edit_shelf_name(self, *_):
+    def test_edit_shelf_name(self):
         """change the name of an editable shelf"""
         view = views.Shelf.as_view()
         shelf = models.Shelf.objects.create(name="Test Shelf", user=self.local_user)
@@ -200,14 +188,13 @@ class ShelfViews(TestCase):
             "", {"privacy": "public", "user": self.local_user.id, "name": "cool name"}
         )
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request, request.user.username, shelf.identifier)
+        view(request, request.user.username, shelf.identifier)
         shelf.refresh_from_db()
 
         self.assertEqual(shelf.name, "cool name")
         self.assertEqual(shelf.identifier, f"testshelf-{shelf.id}")
 
-    def test_edit_shelf_name_not_editable(self, *_):
+    def test_edit_shelf_name_not_editable(self):
         """can't change the name of an non-editable shelf"""
         view = views.Shelf.as_view()
         shelf = self.local_user.shelf_set.get(identifier="to-read")
@@ -217,12 +204,11 @@ class ShelfViews(TestCase):
             "", {"privacy": "public", "user": self.local_user.id, "name": "cool name"}
         )
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request, request.user.username, shelf.identifier)
+        view(request, request.user.username, shelf.identifier)
 
         self.assertEqual(shelf.name, "To Read")
 
-    def test_filter_shelf_found(self, *_):
+    def test_filter_shelf_found(self):
         """display books that match a filter keyword"""
         models.ShelfBook.objects.create(
             book=self.book,
@@ -249,7 +235,7 @@ class ShelfViews(TestCase):
             shelf_book.book.title,
         )
 
-    def test_filter_shelf_none(self, *_):
+    def test_filter_shelf_none(self):
         """display a message when no books match a filter keyword"""
         models.ShelfBook.objects.create(
             book=self.book,

--- a/bookwyrm/tests/views/shelf/test_shelf_actions.py
+++ b/bookwyrm/tests/views/shelf/test_shelf_actions.py
@@ -10,55 +10,43 @@ from django.test.client import RequestFactory
 from bookwyrm import forms, models, views
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.populate_lists_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-@patch("bookwyrm.activitystreams.remove_book_statuses_task.delay")
 class ShelfActionViews(TestCase):
     """tag views"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-            cls.another_user = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@rat.com",
-                "ratword",
-                local=True,
-                localname="rat",
-                remote_id="https://example.com/users/rat",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.another_user = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@rat.com",
+            "ratword",
+            local=True,
+            localname="rat",
+            remote_id="https://example.com/users/rat",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
             remote_id="https://example.com/book/1",
             parent_work=cls.work,
         )
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            cls.shelf = models.Shelf.objects.create(
-                name="Test Shelf", identifier="test-shelf", user=cls.local_user
-            )
+        cls.shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=cls.local_user
+        )
 
     def setUp(self):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_shelve(self, *_):
+    def test_shelve(self):
         """shelve a book"""
         request = self.factory.post(
             "", {"book": self.book.id, "shelf": self.shelf.identifier}
@@ -78,46 +66,43 @@ class ShelfActionViews(TestCase):
         # make sure the book is on the shelf
         self.assertEqual(self.shelf.books.get(), self.book)
 
-    def test_shelve_to_read(self, *_):
+    def test_shelve_to_read(self):
         """special behavior for the to-read shelf"""
         shelf = models.Shelf.objects.get(user=self.local_user, identifier="to-read")
         request = self.factory.post(
             "", {"book": self.book.id, "shelf": shelf.identifier}
         )
         request.user = self.local_user
+        views.shelve(request)
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.shelve(request)
         # make sure the book is on the shelf
         self.assertEqual(shelf.books.get(), self.book)
 
-    def test_shelve_reading(self, *_):
+    def test_shelve_reading(self):
         """special behavior for the reading shelf"""
         shelf = models.Shelf.objects.get(user=self.local_user, identifier="reading")
         request = self.factory.post(
             "", {"book": self.book.id, "shelf": shelf.identifier}
         )
         request.user = self.local_user
+        views.shelve(request)
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.shelve(request)
         # make sure the book is on the shelf
         self.assertEqual(shelf.books.get(), self.book)
 
-    def test_shelve_read(self, *_):
+    def test_shelve_read(self):
         """special behavior for the read shelf"""
         shelf = models.Shelf.objects.get(user=self.local_user, identifier="read")
         request = self.factory.post(
             "", {"book": self.book.id, "shelf": shelf.identifier}
         )
         request.user = self.local_user
+        views.shelve(request)
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.shelve(request)
         # make sure the book is on the shelf
         self.assertEqual(shelf.books.get(), self.book)
 
-    def test_shelve_read_with_change_shelf(self, *_):
+    def test_shelve_read_with_change_shelf(self):
         """special behavior for the read shelf"""
         previous_shelf = models.Shelf.objects.get(
             user=self.local_user, identifier="reading"
@@ -136,19 +121,17 @@ class ShelfActionViews(TestCase):
             },
         )
         request.user = self.local_user
+        views.shelve(request)
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.shelve(request)
         # make sure the book is on the shelf
         self.assertEqual(shelf.books.get(), self.book)
         self.assertEqual(list(previous_shelf.books.all()), [])
 
-    def test_unshelve(self, *_):
+    def test_unshelve(self):
         """remove a book from a shelf"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ShelfBook.objects.create(
-                book=self.book, user=self.local_user, shelf=self.shelf
-            )
+        models.ShelfBook.objects.create(
+            book=self.book, user=self.local_user, shelf=self.shelf
+        )
         item = models.ShelfBook.objects.get()
 
         self.shelf.save()
@@ -164,7 +147,7 @@ class ShelfActionViews(TestCase):
         self.assertEqual(activity["object"]["id"], item.remote_id)
         self.assertEqual(self.shelf.books.count(), 0)
 
-    def test_create_shelf(self, *_):
+    def test_create_shelf(self):
         """a brand new custom shelf"""
         form = forms.ShelfForm()
         form.data["user"] = self.local_user.id
@@ -181,7 +164,7 @@ class ShelfActionViews(TestCase):
         self.assertEqual(shelf.description, "desc")
         self.assertEqual(shelf.user, self.local_user)
 
-    def test_create_shelf_wrong_user(self, *_):
+    def test_create_shelf_wrong_user(self):
         """a brand new custom shelf"""
         form = forms.ShelfForm()
         form.data["user"] = self.another_user.id
@@ -194,7 +177,7 @@ class ShelfActionViews(TestCase):
         with self.assertRaises(PermissionDenied):
             views.create_shelf(request)
 
-    def test_delete_shelf(self, *_):
+    def test_delete_shelf(self):
         """delete a brand new custom shelf"""
         request = self.factory.post("")
         request.user = self.local_user
@@ -204,7 +187,7 @@ class ShelfActionViews(TestCase):
 
         self.assertFalse(models.Shelf.objects.filter(id=shelf_id).exists())
 
-    def test_delete_shelf_unauthorized(self, *_):
+    def test_delete_shelf_unauthorized(self):
         """delete a brand new custom shelf"""
         request = self.factory.post("")
         request.user = self.another_user
@@ -214,12 +197,11 @@ class ShelfActionViews(TestCase):
 
         self.assertTrue(models.Shelf.objects.filter(id=self.shelf.id).exists())
 
-    def test_delete_shelf_has_book(self, *_):
+    def test_delete_shelf_has_book(self):
         """delete a brand new custom shelf"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ShelfBook.objects.create(
-                book=self.book, user=self.local_user, shelf=self.shelf
-            )
+        models.ShelfBook.objects.create(
+            book=self.book, user=self.local_user, shelf=self.shelf
+        )
         request = self.factory.post("")
         request.user = self.local_user
 
@@ -228,7 +210,7 @@ class ShelfActionViews(TestCase):
 
         self.assertTrue(models.Shelf.objects.filter(id=self.shelf.id).exists())
 
-    def test_delete_shelf_not_editable(self, *_):
+    def test_delete_shelf_not_editable(self):
         """delete a brand new custom shelf"""
         shelf = self.local_user.shelf_set.first()
         self.assertFalse(shelf.editable)

--- a/bookwyrm/tests/views/test_annual_summary.py
+++ b/bookwyrm/tests/views/test_annual_summary.py
@@ -1,7 +1,6 @@
 """testing the annual summary page"""
 
 import datetime
-from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
@@ -24,20 +23,15 @@ class AnnualSummary(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-                summary_keys={"2020": "0123456789"},
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+            summary_keys={"2020": "0123456789"},
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -53,7 +47,7 @@ class AnnualSummary(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    def test_annual_summary_not_authenticated(self, *_):
+    def test_annual_summary_not_authenticated(self):
         """there are so many views, this just makes sure it DOESN’T LOAD"""
         view = views.AnnualSummary.as_view()
         request = self.factory.get("")
@@ -62,7 +56,7 @@ class AnnualSummary(TestCase):
         with self.assertRaises(Http404):
             view(request, self.local_user.localname, self.year)
 
-    def test_annual_summary_not_authenticated_with_key(self, *_):
+    def test_annual_summary_not_authenticated_with_key(self):
         """there are so many views, this just makes sure it DOES LOAD"""
         key = self.local_user.summary_keys[self.year]
         view = views.AnnualSummary.as_view()
@@ -78,7 +72,7 @@ class AnnualSummary(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_annual_summary_wrong_year(self, *_):
+    def test_annual_summary_wrong_year(self):
         """there are so many views, this just makes sure it DOESN’T LOAD"""
         view = views.AnnualSummary.as_view()
         request = self.factory.get("")
@@ -87,7 +81,7 @@ class AnnualSummary(TestCase):
         with self.assertRaises(Http404):
             view(request, self.local_user.localname, self.year)
 
-    def test_annual_summary_empty_page(self, *_):
+    def test_annual_summary_empty_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.AnnualSummary.as_view()
         request = self.factory.get("")
@@ -99,9 +93,7 @@ class AnnualSummary(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-    def test_annual_summary_page(self, *_):
+    def test_annual_summary_page(self):
         """there are so many views, this just makes sure it LOADS"""
         models.ReadThrough.objects.create(
             user=self.local_user, book=self.book, finish_date=make_date(2020, 1, 1)
@@ -117,9 +109,7 @@ class AnnualSummary(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-    def test_annual_summary_page_with_review(self, *_):
+    def test_annual_summary_page_with_review(self):
         """there are so many views, this just makes sure it LOADS"""
 
         models.Review.objects.create(
@@ -144,7 +134,7 @@ class AnnualSummary(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_personal_annual_summary(self, *_):
+    def test_personal_annual_summary(self):
         """redirect to unique user url"""
         view = views.personal_annual_summary
         request = self.factory.get("")
@@ -155,7 +145,7 @@ class AnnualSummary(TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result.url, "/user/mouse/2020-in-the-books")
 
-    def test_summary_add_key(self, *_):
+    def test_summary_add_key(self):
         """add shareable key"""
         self.assertFalse("2022" in self.local_user.summary_keys.keys())
 
@@ -167,7 +157,7 @@ class AnnualSummary(TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertIsNotNone(self.local_user.summary_keys["2022"])
 
-    def test_summary_revoke_key(self, *_):
+    def test_summary_revoke_key(self):
         """add shareable key"""
         self.assertTrue("2020" in self.local_user.summary_keys.keys())
 

--- a/bookwyrm/tests/views/test_author.py
+++ b/bookwyrm/tests/views/test_author.py
@@ -20,19 +20,14 @@ class AuthorViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         cls.group = Group.objects.create(name="editor")
         cls.group.permissions.add(
             Permission.objects.create(
@@ -153,8 +148,7 @@ class AuthorViews(TestCase):
         request = self.factory.post("", form.data)
         request.user = self.local_user
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request, author.id)
+        view(request, author.id)
         author.refresh_from_db()
         self.assertEqual(author.name, "New Name")
         self.assertEqual(author.last_edited_by, self.local_user)

--- a/bookwyrm/tests/views/test_directory.py
+++ b/bookwyrm/tests/views/test_directory.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import AnonymousUser
 from django.template.response import TemplateResponse
 from django.test import TestCase
@@ -17,19 +15,14 @@ class DirectoryViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -37,11 +30,7 @@ class DirectoryViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    @patch("bookwyrm.lists_stream.populate_lists_task.delay")
-    @patch("bookwyrm.suggested_users.rerank_user_task.delay")
-    def test_directory_page(self, *_):
+    def test_directory_page(self):
         """there are so many views, this just makes sure it LOADS"""
         models.User.objects.create_user(
             "rat@local.com",

--- a/bookwyrm/tests/views/test_discover.py
+++ b/bookwyrm/tests/views/test_discover.py
@@ -15,18 +15,14 @@ class DiscoverViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        models.SiteSettings.objects.create()
 
     def setUp(self):
         """individual test setup"""
@@ -47,9 +43,7 @@ class DiscoverViews(TestCase):
         self.assertEqual(result.status_code, 200)
         validate_html(result.render())
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_discover_page_with_posts(self, *_):
+    def test_discover_page_with_posts(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Discover.as_view()
         request = self.factory.get("")

--- a/bookwyrm/tests/views/test_feed.py
+++ b/bookwyrm/tests/views/test_feed.py
@@ -13,37 +13,26 @@ from bookwyrm.activitypub import ActivitypubResponse
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.activitystreams.ActivityStream.get_activity_stream")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.populate_lists_task.delay")
-@patch("bookwyrm.suggested_users.remove_user_task.delay")
 class FeedViews(TestCase):
     """activity feed, statuses, dms"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.another_user = models.User.objects.create_user(
-                "nutria@local.com",
-                "nutria@nutria.nutria",
-                "password",
-                local=True,
-                localname="nutria",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.another_user = models.User.objects.create_user(
+            "nutria@local.com",
+            "nutria@nutria.nutria",
+            "password",
+            local=True,
+            localname="nutria",
+        )
         cls.book = models.Edition.objects.create(
             parent_work=models.Work.objects.create(title="hi"),
             title="Example Edition",
@@ -55,6 +44,7 @@ class FeedViews(TestCase):
         self.factory = RequestFactory()
 
     @patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions")
+    @patch("bookwyrm.activitystreams.ActivityStream.get_activity_stream")
     def test_feed(self, *_):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Feed.as_view()
@@ -66,6 +56,7 @@ class FeedViews(TestCase):
         self.assertEqual(result.status_code, 200)
 
     @patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions")
+    @patch("bookwyrm.activitystreams.ActivityStream.get_activity_stream")
     def test_save_feed_settings(self, *_):
         """update display preferences"""
         self.assertEqual(
@@ -84,11 +75,10 @@ class FeedViews(TestCase):
         self.local_user.refresh_from_db()
         self.assertEqual(self.local_user.feed_status_types, ["review"])
 
-    def test_status_page(self, *_):
+    def test_status_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Status.as_view()
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Status.objects.create(content="hi", user=self.local_user)
+        status = models.Status.objects.create(content="hi", user=self.local_user)
         request = self.factory.get("")
         request.user = self.local_user
         with patch("bookwyrm.views.feed.is_api_request") as is_api:
@@ -104,7 +94,7 @@ class FeedViews(TestCase):
         self.assertIsInstance(result, ActivitypubResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_status_page_not_found(self, *_):
+    def test_status_page_not_found(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Status.as_view()
 
@@ -115,7 +105,7 @@ class FeedViews(TestCase):
             with self.assertRaises(Http404):
                 view(request, "mouse", 12345)
 
-    def test_status_page_not_found_wrong_user(self, *_):
+    def test_status_page_not_found_wrong_user(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Status.as_view()
         another_user = models.User.objects.create_user(
@@ -125,8 +115,7 @@ class FeedViews(TestCase):
             local=True,
             localname="rat",
         )
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Status.objects.create(content="hi", user=another_user)
+        status = models.Status.objects.create(content="hi", user=another_user)
 
         request = self.factory.get("")
         request.user = self.local_user
@@ -135,24 +124,21 @@ class FeedViews(TestCase):
             with self.assertRaises(Http404):
                 view(request, "mouse", status.id)
 
-    def test_status_page_with_image(self, *_):
+    def test_status_page_with_image(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Status.as_view()
 
         image_path = pathlib.Path(__file__).parent.joinpath(
             "../../static/images/default_avi.jpg"
         )
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Review.objects.create(
-                content="hi",
-                user=self.local_user,
-                book=self.book,
-            )
-            attachment = models.Image.objects.create(
-                status=status, caption="alt text here"
-            )
-            with open(image_path, "rb") as image_file:
-                attachment.image.save("test.jpg", image_file)
+        status = models.Review.objects.create(
+            content="hi",
+            user=self.local_user,
+            book=self.book,
+        )
+        attachment = models.Image.objects.create(status=status, caption="alt text here")
+        with open(image_path, "rb") as image_file:
+            attachment.image.save("test.jpg", image_file)
 
         request = self.factory.get("")
         request.user = self.local_user
@@ -169,11 +155,10 @@ class FeedViews(TestCase):
         self.assertIsInstance(result, ActivitypubResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_replies_page(self, *_):
+    def test_replies_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Replies.as_view()
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            status = models.Status.objects.create(content="hi", user=self.local_user)
+        status = models.Status.objects.create(content="hi", user=self.local_user)
         request = self.factory.get("")
         request.user = self.local_user
         with patch("bookwyrm.views.feed.is_api_request") as is_api:
@@ -189,7 +174,7 @@ class FeedViews(TestCase):
         self.assertIsInstance(result, ActivitypubResponse)
         self.assertEqual(result.status_code, 200)
 
-    def test_direct_messages_page(self, *_):
+    def test_direct_messages_page(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.DirectMessage.as_view()
         request = self.factory.get("")
@@ -199,7 +184,7 @@ class FeedViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_direct_messages_page_user(self, *_):
+    def test_direct_messages_page_user(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.DirectMessage.as_view()
         request = self.factory.get("")
@@ -210,9 +195,7 @@ class FeedViews(TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.context_data["partner"], self.another_user)
 
-    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-    @patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-    def test_get_suggested_book(self, *_):
+    def test_get_suggested_book(self):
         """gets books the ~*~ algorithm ~*~ thinks you want to post about"""
         models.ShelfBook.objects.create(
             book=self.book,

--- a/bookwyrm/tests/views/test_follow.py
+++ b/bookwyrm/tests/views/test_follow.py
@@ -13,37 +13,29 @@ from bookwyrm import models, views
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.activitystreams.add_user_statuses_task.delay")
-@patch("bookwyrm.lists_stream.add_user_lists_task.delay")
 class FollowViews(TestCase):
     """follows"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@email.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@email.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.group = Group.objects.create(name="editor")
         cls.group.permissions.add(
             Permission.objects.create(
@@ -63,14 +55,13 @@ class FollowViews(TestCase):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_handle_follow_remote(self, *_):
+    def test_handle_follow_remote(self):
         """send a follow request"""
         request = self.factory.post("", {"user": self.remote_user.username})
         request.user = self.local_user
         self.assertEqual(models.UserFollowRequest.objects.count(), 0)
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.follow(request)
+        views.follow(request)
 
         rel = models.UserFollowRequest.objects.get()
 
@@ -78,65 +69,50 @@ class FollowViews(TestCase):
         self.assertEqual(rel.user_object, self.remote_user)
         self.assertEqual(rel.status, "follow_request")
 
-    def test_handle_follow_local_manually_approves(self, *_):
+    def test_handle_follow_local_manually_approves(self):
         """send a follow request"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            rat = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@rat.com",
-                "ratword",
-                local=True,
-                localname="rat",
-                remote_id="https://example.com/users/rat",
-                manually_approves_followers=True,
-            )
+        rat = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@rat.com",
+            "ratword",
+            local=True,
+            localname="rat",
+            remote_id="https://example.com/users/rat",
+            manually_approves_followers=True,
+        )
         request = self.factory.post("", {"user": rat})
         request.user = self.local_user
         self.assertEqual(models.UserFollowRequest.objects.count(), 0)
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.follow(request)
+        views.follow(request)
         rel = models.UserFollowRequest.objects.get()
 
         self.assertEqual(rel.user_subject, self.local_user)
         self.assertEqual(rel.user_object, rat)
         self.assertEqual(rel.status, "follow_request")
 
-    def test_handle_follow_local(self, *_):
+    def test_handle_follow_local(self):
         """send a follow request"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            rat = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@rat.com",
-                "ratword",
-                local=True,
-                localname="rat",
-                remote_id="https://example.com/users/rat",
-            )
+        rat = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@rat.com",
+            "ratword",
+            local=True,
+            localname="rat",
+            remote_id="https://example.com/users/rat",
+        )
         request = self.factory.post("", {"user": rat})
         request.user = self.local_user
         self.assertEqual(models.UserFollowRequest.objects.count(), 0)
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.follow(request)
-
+        views.follow(request)
         rel = models.UserFollows.objects.get()
 
         self.assertEqual(rel.user_subject, self.local_user)
         self.assertEqual(rel.user_object, rat)
         self.assertEqual(rel.status, "follows")
 
-    @patch("bookwyrm.activitystreams.remove_user_statuses_task.delay")
-    @patch("bookwyrm.lists_stream.remove_user_lists_task.delay")
-    def test_handle_unfollow(self, *_):
+    def test_handle_unfollow(self):
         """send an unfollow"""
         request = self.factory.post("", {"user": self.remote_user.username})
         request.user = self.local_user
@@ -152,7 +128,7 @@ class FollowViews(TestCase):
 
         self.assertEqual(self.remote_user.followers.count(), 0)
 
-    def test_handle_accept(self, *_):
+    def test_handle_accept(self):
         """accept a follow request"""
         self.local_user.manually_approves_followers = True
         self.local_user.save(
@@ -164,14 +140,13 @@ class FollowViews(TestCase):
             user_subject=self.remote_user, user_object=self.local_user
         )
 
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.accept_follow_request(request)
+        views.accept_follow_request(request)
         # request should be deleted
         self.assertEqual(models.UserFollowRequest.objects.filter(id=rel.id).count(), 0)
         # follow relationship should exist
         self.assertEqual(self.local_user.followers.first(), self.remote_user)
 
-    def test_handle_reject(self, *_):
+    def test_handle_reject(self):
         """reject a follow request"""
         self.local_user.manually_approves_followers = True
         self.local_user.save(
@@ -197,7 +172,7 @@ class FollowViews(TestCase):
         # follow relationship should not exist
         self.assertEqual(models.UserFollows.objects.filter(id=rel.id).count(), 0)
 
-    def test_handle_reject_existing(self, *_):
+    def test_handle_reject_existing(self):
         """reject a follow previously approved"""
         request = self.factory.post("", {"user": self.remote_user.username})
         request.user = self.local_user
@@ -216,7 +191,7 @@ class FollowViews(TestCase):
         # follow relationship should not exist
         self.assertEqual(models.UserFollows.objects.filter(id=rel.id).count(), 0)
 
-    def test_ostatus_follow_request(self, *_):
+    def test_ostatus_follow_request(self):
         """check ostatus subscribe template loads"""
         request = self.factory.get(
             "", {"acct": "https%3A%2F%2Fexample.com%2Fusers%2Frat"}
@@ -227,7 +202,7 @@ class FollowViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_remote_follow_page(self, *_):
+    def test_remote_follow_page(self):
         """check remote follow page loads"""
         request = self.factory.get("", {"acct": "mouse@local.com"})
         request.user = self.remote_user
@@ -236,7 +211,7 @@ class FollowViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_ostatus_follow_success(self, *_):
+    def test_ostatus_follow_success(self):
         """check remote follow success page loads"""
         request = self.factory.get("")
         request.user = self.remote_user
@@ -246,7 +221,7 @@ class FollowViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_remote_follow(self, *_):
+    def test_remote_follow(self):
         """check follow from remote page loads"""
         request = self.factory.post("", {"user": self.remote_user.id})
         request.user = self.remote_user

--- a/bookwyrm/tests/views/test_get_started.py
+++ b/bookwyrm/tests/views/test_get_started.py
@@ -9,32 +9,26 @@ from bookwyrm import forms, models, views
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
 class GetStartedViews(TestCase):
     """helping new users get oriented"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.local_user = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@rat.rat",
-                "password",
-                local=True,
-                localname="rat",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.local_user = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@rat.rat",
+            "password",
+            local=True,
+            localname="rat",
+        )
         cls.book = models.Edition.objects.create(
             parent_work=models.Work.objects.create(title="hi"),
             title="Example Edition",
@@ -45,7 +39,7 @@ class GetStartedViews(TestCase):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_profile_view(self, *_):
+    def test_profile_view(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.GetStartedProfile.as_view()
         request = self.factory.get("")
@@ -57,9 +51,7 @@ class GetStartedViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.suggested_users.rerank_user_task.delay")
-    def test_profile_view_post(self, *_):
+    def test_profile_view_post(self):
         """save basic user details"""
         view = views.GetStartedProfile.as_view()
         form = forms.LimitedEditUserForm(instance=self.local_user)
@@ -77,7 +69,7 @@ class GetStartedViews(TestCase):
         self.assertEqual(self.local_user.name, "New Name")
         self.assertTrue(self.local_user.discoverable)
 
-    def test_books_view(self, _):
+    def test_books_view(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.GetStartedBooks.as_view()
         request = self.factory.get("")
@@ -89,7 +81,7 @@ class GetStartedViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_books_view_with_query(self, _):
+    def test_books_view_with_query(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.GetStartedBooks.as_view()
         request = self.factory.get("?query=Example")
@@ -101,9 +93,7 @@ class GetStartedViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-    def test_books_view_post(self, *_):
+    def test_books_view_post(self):
         """shelve some books"""
         view = views.GetStartedBooks.as_view()
         data = {self.book.id: self.local_user.shelf_set.first().id}
@@ -121,20 +111,20 @@ class GetStartedViews(TestCase):
         self.assertEqual(shelfbook.book, self.book)
         self.assertEqual(shelfbook.user, self.local_user)
 
-    @patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions")
-    def test_users_view(self, *_):
+    def test_users_view(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.GetStartedUsers.as_view()
         request = self.factory.get("")
         request.user = self.local_user
 
-        result = view(request)
+        with patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions"):
+            result = view(request)
 
         self.assertIsInstance(result, TemplateResponse)
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_users_view_with_query(self, *_):
+    def test_users_view_with_query(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.GetStartedUsers.as_view()
         request = self.factory.get("?query=rat")

--- a/bookwyrm/tests/views/test_goal.py
+++ b/bookwyrm/tests/views/test_goal.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
 from django.template.response import TemplateResponse
@@ -19,27 +17,22 @@ class GoalViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@rat.com",
-                "ratword",
-                local=True,
-                localname="rat",
-                remote_id="https://example.com/users/rat",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@rat.com",
+            "ratword",
+            local=True,
+            localname="rat",
+            remote_id="https://example.com/users/rat",
+        )
         cls.book = models.Edition.objects.create(
             title="Example Edition",
             remote_id="https://example.com/book/1",
@@ -114,8 +107,7 @@ class GoalViews(TestCase):
         with self.assertRaises(Http404):
             view(request, self.local_user.localname, self.year)
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_create_goal(self, _):
+    def test_create_goal(self):
         """create a new goal"""
         view = views.Goal.as_view()
         request = self.factory.post(
@@ -129,8 +121,7 @@ class GoalViews(TestCase):
             },
         )
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            view(request, self.local_user.localname, self.year)
+        view(request, self.local_user.localname, self.year)
 
         goal = models.AnnualGoal.objects.get()
         self.assertEqual(goal.user, self.local_user)

--- a/bookwyrm/tests/views/test_group.py
+++ b/bookwyrm/tests/views/test_group.py
@@ -13,33 +13,26 @@ from bookwyrm import models, views
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class GroupViews(TestCase):
     """view group and edit details"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@rat.rat",
-                "password",
-                local=True,
-                localname="rat",
-            )
-
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@rat.rat",
+            "password",
+            local=True,
+            localname="rat",
+        )
         cls.testgroup = models.Group.objects.create(
             name="Test Group",
             description="Initial description",
@@ -56,7 +49,7 @@ class GroupViews(TestCase):
         self.anonymous_user = AnonymousUser
         self.anonymous_user.is_authenticated = False
 
-    def test_group_get(self, _):
+    def test_group_get(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Group.as_view()
         request = self.factory.get("")
@@ -66,7 +59,7 @@ class GroupViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_group_get_anonymous(self, _):
+    def test_group_get_anonymous(self):
         """there are so many views, this just makes sure it LOADS"""
         self.testgroup.privacy = "followers"
         self.testgroup.save()
@@ -77,7 +70,7 @@ class GroupViews(TestCase):
         with self.assertRaises(Http404):
             view(request, group_id=self.testgroup.id)
 
-    def test_usergroups_get(self, _):
+    def test_usergroups_get(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.UserGroups.as_view()
         request = self.factory.get("")
@@ -87,7 +80,7 @@ class GroupViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_usergroups_get_anonymous(self, _):
+    def test_usergroups_get_anonymous(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.UserGroups.as_view()
         request = self.factory.get("")
@@ -97,18 +90,18 @@ class GroupViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    @patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions")
-    def test_findusers_get(self, *_):
+    def test_findusers_get(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.FindUsers.as_view()
         request = self.factory.get("")
         request.user = self.local_user
-        result = view(request, group_id=self.testgroup.id)
+        with patch("bookwyrm.suggested_users.SuggestedUsers.get_suggestions"):
+            result = view(request, group_id=self.testgroup.id)
         self.assertIsInstance(result, TemplateResponse)
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_findusers_get_with_query(self, _):
+    def test_findusers_get_with_query(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.FindUsers.as_view()
         request = self.factory.get("", {"user_query": "rat"})
@@ -120,7 +113,7 @@ class GroupViews(TestCase):
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_group_create(self, _):
+    def test_group_create(self):
         """create group view"""
         view = views.UserGroups.as_view()
         request = self.factory.post(
@@ -145,7 +138,7 @@ class GroupViews(TestCase):
             ).exists()
         )
 
-    def test_group_create_permission_denied(self, _):
+    def test_group_create_permission_denied(self):
         """create group view"""
         view = views.UserGroups.as_view()
         request = self.factory.post(
@@ -162,7 +155,7 @@ class GroupViews(TestCase):
         with self.assertRaises(PermissionDenied):
             view(request, "username")
 
-    def test_group_edit(self, _):
+    def test_group_edit(self):
         """test editing a "group" database entry"""
         view = views.Group.as_view()
         request = self.factory.post(
@@ -183,14 +176,14 @@ class GroupViews(TestCase):
         self.assertEqual(self.testgroup.description, "wow")
         self.assertEqual(self.testgroup.privacy, "direct")
 
-    def test_delete_group(self, _):
+    def test_delete_group(self):
         """delete a group"""
         request = self.factory.post("")
         request.user = self.local_user
         views.delete_group(request, self.testgroup.id)
         self.assertFalse(models.Group.objects.exists())
 
-    def test_invite_member(self, _):
+    def test_invite_member(self):
         """invite a member to a group"""
         request = self.factory.post(
             "",
@@ -207,7 +200,7 @@ class GroupViews(TestCase):
         self.assertEqual(invite.user, self.rat)
         self.assertEqual(invite.group, self.testgroup)
 
-    def test_invite_member_twice(self, _):
+    def test_invite_member_twice(self):
         """invite a member to a group again"""
         request = self.factory.post(
             "",
@@ -222,7 +215,7 @@ class GroupViews(TestCase):
         result = views.invite_member(request)
         self.assertEqual(result.status_code, 302)
 
-    def test_remove_member_denied(self, _):
+    def test_remove_member_denied(self):
         """remove member"""
         request = self.factory.post(
             "",
@@ -235,7 +228,7 @@ class GroupViews(TestCase):
         result = views.remove_member(request)
         self.assertEqual(result.status_code, 400)
 
-    def test_remove_member_non_member(self, _):
+    def test_remove_member_non_member(self):
         """remove member but wait, that's not a member"""
         request = self.factory.post(
             "",
@@ -249,7 +242,7 @@ class GroupViews(TestCase):
         # nothing happens
         self.assertEqual(result.status_code, 302)
 
-    def test_remove_member_invited(self, _):
+    def test_remove_member_invited(self):
         """remove an invited member"""
         models.GroupMemberInvitation.objects.create(
             user=self.rat,
@@ -267,7 +260,7 @@ class GroupViews(TestCase):
         self.assertEqual(result.status_code, 302)
         self.assertFalse(models.GroupMemberInvitation.objects.exists())
 
-    def test_remove_member_existing_member(self, _):
+    def test_remove_member_existing_member(self):
         """remove an invited member"""
         models.GroupMember.objects.create(
             user=self.rat,
@@ -290,7 +283,7 @@ class GroupViews(TestCase):
         self.assertEqual(notification.related_group, self.testgroup)
         self.assertEqual(notification.notification_type, "REMOVE")
 
-    def test_remove_member_remove_self(self, _):
+    def test_remove_member_remove_self(self):
         """Leave a group"""
         models.GroupMember.objects.create(
             user=self.rat,
@@ -313,7 +306,7 @@ class GroupViews(TestCase):
         self.assertEqual(notification.related_group, self.testgroup)
         self.assertEqual(notification.notification_type, "LEAVE")
 
-    def test_accept_membership(self, _):
+    def test_accept_membership(self):
         """accept an invite"""
         models.GroupMemberInvitation.objects.create(
             user=self.rat,
@@ -326,7 +319,7 @@ class GroupViews(TestCase):
         self.assertFalse(models.GroupMemberInvitation.objects.exists())
         self.assertTrue(self.rat in [m.user for m in self.testgroup.memberships.all()])
 
-    def test_reject_membership(self, _):
+    def test_reject_membership(self):
         """reject an invite"""
         models.GroupMemberInvitation.objects.create(
             user=self.rat,

--- a/bookwyrm/tests/views/test_hashtag.py
+++ b/bookwyrm/tests/views/test_hashtag.py
@@ -1,7 +1,5 @@
 """tests for hashtag view"""
 
-from unittest.mock import patch
-
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
 from django.template.response import TemplateResponse
@@ -17,37 +15,31 @@ class HashtagView(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-            cls.follower_user = models.User.objects.create_user(
-                "follower@local.com",
-                "follower@email.com",
-                "followerword",
-                local=True,
-                localname="follower",
-                remote_id="https://example.com/users/follower",
-            )
-            cls.local_user.followers.add(cls.follower_user)
-            cls.other_user = models.User.objects.create_user(
-                "other@local.com",
-                "other@email.com",
-                "otherword",
-                local=True,
-                localname="other",
-                remote_id="https://example.com/users/other",
-            )
-
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.follower_user = models.User.objects.create_user(
+            "follower@local.com",
+            "follower@email.com",
+            "followerword",
+            local=True,
+            localname="follower",
+            remote_id="https://example.com/users/follower",
+        )
+        cls.local_user.followers.add(cls.follower_user)
+        cls.other_user = models.User.objects.create_user(
+            "other@local.com",
+            "other@email.com",
+            "otherword",
+            local=True,
+            localname="other",
+            remote_id="https://example.com/users/other",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -56,15 +48,11 @@ class HashtagView(TestCase):
         )
 
         cls.hashtag_bookclub = models.Hashtag.objects.create(name="#BookClub")
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_status_task.delay"),
-        ):
-            cls.statuses_bookclub = [
-                models.Comment.objects.create(
-                    book=cls.book, user=cls.local_user, content="#BookClub"
-                ),
-            ]
+        cls.statuses_bookclub = [
+            models.Comment.objects.create(
+                book=cls.book, user=cls.local_user, content="#BookClub"
+            ),
+        ]
         for status in cls.statuses_bookclub:
             status.mention_hashtags.add(cls.hashtag_bookclub)
 
@@ -93,14 +81,10 @@ class HashtagView(TestCase):
         request = self.factory.get("")
 
         hashtag = models.Hashtag.objects.create(name="#test")
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_status_task.delay"),
-        ):
-            status = models.Comment.objects.create(
-                user=self.local_user, book=self.book, content="#test", privacy="direct"
-            )
-            status.mention_hashtags.add(hashtag)
+        status = models.Comment.objects.create(
+            user=self.local_user, book=self.book, content="#test", privacy="direct"
+        )
+        status.mention_hashtags.add(hashtag)
 
         for user in [
             self.local_user,
@@ -118,17 +102,13 @@ class HashtagView(TestCase):
         request = self.factory.get("")
 
         hashtag = models.Hashtag.objects.create(name="#test")
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_status_task.delay"),
-        ):
-            status = models.Comment.objects.create(
-                user=self.local_user,
-                book=self.book,
-                content="#test",
-                privacy="unlisted",
-            )
-            status.mention_hashtags.add(hashtag)
+        status = models.Comment.objects.create(
+            user=self.local_user,
+            book=self.book,
+            content="#test",
+            privacy="unlisted",
+        )
+        status.mention_hashtags.add(hashtag)
 
         for user in [
             self.local_user,
@@ -147,17 +127,13 @@ class HashtagView(TestCase):
         request = self.factory.get("")
 
         hashtag = models.Hashtag.objects.create(name="#test")
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_status_task.delay"),
-        ):
-            status = models.Comment.objects.create(
-                user=self.local_user,
-                book=self.book,
-                content="#test",
-                privacy="followers",
-            )
-            status.mention_hashtags.add(hashtag)
+        status = models.Comment.objects.create(
+            user=self.local_user,
+            book=self.book,
+            content="#test",
+            privacy="followers",
+        )
+        status.mention_hashtags.add(hashtag)
 
         for user in [self.local_user, self.follower_user]:
             request.user = user

--- a/bookwyrm/tests/views/test_helpers.py
+++ b/bookwyrm/tests/views/test_helpers.py
@@ -1,7 +1,6 @@
 """test for app action functionality"""
 
 import json
-from unittest.mock import patch
 import pathlib
 from django.http import Http404
 from django.test import TestCase
@@ -12,55 +11,40 @@ from bookwyrm import models, views
 from bookwyrm.settings import USER_AGENT, BASE_URL
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.suggested_users.rerank_user_task.delay")
 class ViewsHelpers(TestCase):
     """viewing and creating statuses"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                discoverable=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-        with (
-            patch("bookwyrm.models.user.set_remote_server.delay"),
-            patch("bookwyrm.suggested_users.rerank_user_task.delay"),
-        ):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                discoverable=True,
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            discoverable=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            discoverable=True,
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Test Book",
             remote_id="https://example.com/book/1",
             parent_work=cls.work,
         )
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            cls.shelf = models.Shelf.objects.create(
-                name="Test Shelf", identifier="test-shelf", user=cls.local_user
-            )
+        cls.shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=cls.local_user
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -69,12 +53,12 @@ class ViewsHelpers(TestCase):
         self.userdata = json.loads(datafile.read_bytes())
         del self.userdata["icon"]
 
-    def test_get_edition(self, *_):
+    def test_get_edition(self):
         """given an edition or a work, returns an edition"""
         self.assertEqual(views.helpers.get_edition(self.book.id), self.book)
         self.assertEqual(views.helpers.get_edition(self.work.id), self.book)
 
-    def test_get_user_from_username(self, *_):
+    def test_get_user_from_username(self):
         """works for either localname or username"""
         self.assertEqual(
             views.helpers.get_user_from_username(self.local_user, "mouse"),
@@ -87,7 +71,7 @@ class ViewsHelpers(TestCase):
         with self.assertRaises(Http404):
             views.helpers.get_user_from_username(self.local_user, "mojfse@example.com")
 
-    def test_is_api_request(self, *_):
+    def test_is_api_request(self):
         """should it return html or json"""
         request = self.factory.get("/path")
         request.headers = {"Accept": "application/json"}
@@ -101,12 +85,12 @@ class ViewsHelpers(TestCase):
         request.headers = {"Accept": "Praise"}
         self.assertFalse(views.helpers.is_api_request(request))
 
-    def test_is_api_request_no_headers(self, *_):
+    def test_is_api_request_no_headers(self):
         """should it return html or json"""
         request = self.factory.get("/path")
         self.assertFalse(views.helpers.is_api_request(request))
 
-    def test_is_bookwyrm_request(self, *_):
+    def test_is_bookwyrm_request(self):
         """checks if a request came from a bookwyrm instance"""
         request = self.factory.get("", {"q": "Test Book"})
         self.assertFalse(views.helpers.is_bookwyrm_request(request))
@@ -129,7 +113,7 @@ class ViewsHelpers(TestCase):
         )
         self.assertTrue(views.helpers.is_bookwyrm_request(request))
 
-    def test_handle_remote_webfinger_invalid(self, *_):
+    def test_handle_remote_webfinger_invalid(self):
         """Various ways you can send a bad query"""
         # if there's no query, there's no result
         result = views.helpers.handle_remote_webfinger(None)
@@ -139,7 +123,7 @@ class ViewsHelpers(TestCase):
         result = views.helpers.handle_remote_webfinger("noatsymbol")
         self.assertIsNone(result)
 
-    def test_handle_remote_webfinger_existing_user(self, *_):
+    def test_handle_remote_webfinger_existing_user(self):
         """simple database lookup by username"""
         result = views.helpers.handle_remote_webfinger("@mouse@local.com")
         self.assertEqual(result, self.local_user)
@@ -151,7 +135,7 @@ class ViewsHelpers(TestCase):
         self.assertEqual(result, self.local_user)
 
     @responses.activate
-    def test_handle_remote_webfinger_load_user_invalid_result(self, *_):
+    def test_handle_remote_webfinger_load_user_invalid_result(self):
         """find a remote user using webfinger, but fail"""
         username = "mouse@example.com"
         responses.add(
@@ -163,7 +147,7 @@ class ViewsHelpers(TestCase):
         self.assertIsNone(result)
 
     @responses.activate
-    def test_handle_remote_webfinger_load_user(self, *_):
+    def test_handle_remote_webfinger_load_user(self):
         """find a remote user using webfinger"""
         username = "mouse@example.com"
         wellknown = {
@@ -188,12 +172,11 @@ class ViewsHelpers(TestCase):
             json=self.userdata,
             status=200,
         )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            result = views.helpers.handle_remote_webfinger("@mouse@example.com")
-            self.assertIsInstance(result, models.User)
-            self.assertEqual(result.username, "mouse@example.com")
+        result = views.helpers.handle_remote_webfinger("@mouse@example.com")
+        self.assertIsInstance(result, models.User)
+        self.assertEqual(result.username, "mouse@example.com")
 
-    def test_handler_remote_webfinger_user_on_blocked_server(self, *_):
+    def test_handler_remote_webfinger_user_on_blocked_server(self):
         """find a remote user using webfinger"""
         models.FederatedServer.objects.create(
             server_name="example.com", status="blocked"
@@ -203,7 +186,7 @@ class ViewsHelpers(TestCase):
         self.assertIsNone(result)
 
     @responses.activate
-    def test_subscribe_remote_webfinger(self, *_):
+    def test_subscribe_remote_webfinger(self):
         """remote subscribe templates"""
         query = "mouse@example.com"
         response = {
@@ -234,51 +217,41 @@ class ViewsHelpers(TestCase):
         template = views.helpers.subscribe_remote_webfinger(f"@{query}")
         self.assertEqual(template, "hello")
 
-    def test_handle_reading_status_to_read(self, *_):
+    def test_handle_reading_status_to_read(self):
         """posts shelve activities"""
         shelf = self.local_user.shelf_set.get(identifier="to-read")
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.helpers.handle_reading_status(
-                self.local_user, shelf, self.book, "public"
-            )
+        views.helpers.handle_reading_status(self.local_user, shelf, self.book, "public")
         status = models.GeneratedNote.objects.get()
         self.assertEqual(status.user, self.local_user)
         self.assertEqual(status.mention_books.first(), self.book)
         self.assertEqual(status.content, "wants to read")
 
-    def test_handle_reading_status_reading(self, *_):
+    def test_handle_reading_status_reading(self):
         """posts shelve activities"""
         shelf = self.local_user.shelf_set.get(identifier="reading")
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.helpers.handle_reading_status(
-                self.local_user, shelf, self.book, "public"
-            )
+        views.helpers.handle_reading_status(self.local_user, shelf, self.book, "public")
         status = models.GeneratedNote.objects.get()
         self.assertEqual(status.user, self.local_user)
         self.assertEqual(status.mention_books.first(), self.book)
         self.assertEqual(status.content, "started reading")
 
-    def test_handle_reading_status_read(self, *_):
+    def test_handle_reading_status_read(self):
         """posts shelve activities"""
         shelf = self.local_user.shelf_set.get(identifier="read")
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.helpers.handle_reading_status(
-                self.local_user, shelf, self.book, "public"
-            )
+        views.helpers.handle_reading_status(self.local_user, shelf, self.book, "public")
         status = models.GeneratedNote.objects.get()
         self.assertEqual(status.user, self.local_user)
         self.assertEqual(status.mention_books.first(), self.book)
         self.assertEqual(status.content, "finished reading")
 
-    def test_handle_reading_status_other(self, *_):
+    def test_handle_reading_status_other(self):
         """posts shelve activities"""
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.helpers.handle_reading_status(
-                self.local_user, self.shelf, self.book, "public"
-            )
+        views.helpers.handle_reading_status(
+            self.local_user, self.shelf, self.book, "public"
+        )
         self.assertFalse(models.GeneratedNote.objects.exists())
 
-    def test_redirect_to_referer_outside_domain(self, *_):
+    def test_redirect_to_referer_outside_domain(self):
         """safely send people on their way"""
         request = self.factory.get(
             "/path",
@@ -291,7 +264,7 @@ class ViewsHelpers(TestCase):
         )
         self.assertEqual(result.url, f"/user/{self.local_user.localname}")
 
-    def test_redirect_to_referer_outside_domain_with_fallback(self, *_):
+    def test_redirect_to_referer_outside_domain_with_fallback(self):
         """invalid domain with regular params for the redirect function"""
         request = self.factory.get(
             "/path",
@@ -302,7 +275,7 @@ class ViewsHelpers(TestCase):
         result = views.helpers.redirect_to_referer(request)
         self.assertEqual(result.url, "/")
 
-    def test_redirect_to_referer_valid_domain(self, *_):
+    def test_redirect_to_referer_valid_domain(self):
         """redirect to within the app"""
         request = self.factory.get(
             "/path",
@@ -313,7 +286,7 @@ class ViewsHelpers(TestCase):
         result = views.helpers.redirect_to_referer(request)
         self.assertEqual(result.url, f"{BASE_URL}/and/a/path")
 
-    def test_redirect_to_referer_with_get_args(self, *_):
+    def test_redirect_to_referer_with_get_args(self):
         """if the path has get params (like sort) they are preserved"""
         request = self.factory.get(
             "/path",

--- a/bookwyrm/tests/views/test_interaction.py
+++ b/bookwyrm/tests/views/test_interaction.py
@@ -8,37 +8,29 @@ from django.test.client import RequestFactory
 from bookwyrm import models, views
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
 class InteractionViews(TestCase):
     """viewing and creating statuses"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@email.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@email.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -50,7 +42,7 @@ class InteractionViews(TestCase):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_favorite(self, *_):
+    def test_favorite(self):
         """create and broadcast faving a status"""
         view = views.Favorite.as_view()
         request = self.factory.post("")
@@ -68,7 +60,7 @@ class InteractionViews(TestCase):
         self.assertEqual(notification.user, self.local_user)
         self.assertEqual(notification.related_users.first(), self.remote_user)
 
-    def test_unfavorite(self, *_):
+    def test_unfavorite(self):
         """unfav a status"""
         view = views.Unfavorite.as_view()
         request = self.factory.post("")
@@ -85,7 +77,7 @@ class InteractionViews(TestCase):
         self.assertEqual(models.Favorite.objects.count(), 0)
         self.assertEqual(models.Notification.objects.count(), 0)
 
-    def test_boost(self, *_):
+    def test_boost(self):
         """boost a status"""
         view = views.Boost.as_view()
         request = self.factory.post("")
@@ -107,7 +99,7 @@ class InteractionViews(TestCase):
         self.assertEqual(notification.related_users.first(), self.remote_user)
         self.assertEqual(notification.related_status, status)
 
-    def test_self_boost(self, *_):
+    def test_self_boost(self):
         """boost your own status"""
         view = views.Boost.as_view()
         request = self.factory.post("")
@@ -131,7 +123,7 @@ class InteractionViews(TestCase):
 
         self.assertFalse(models.Notification.objects.exists())
 
-    def test_boost_unlisted(self, *_):
+    def test_boost_unlisted(self):
         """boost a status"""
         view = views.Boost.as_view()
         request = self.factory.post("")
@@ -146,7 +138,7 @@ class InteractionViews(TestCase):
         boost = models.Boost.objects.get()
         self.assertEqual(boost.privacy, "unlisted")
 
-    def test_boost_private(self, *_):
+    def test_boost_private(self):
         """boost a status"""
         view = views.Boost.as_view()
         request = self.factory.post("")
@@ -159,7 +151,7 @@ class InteractionViews(TestCase):
             view(request, status.id)
         self.assertFalse(models.Boost.objects.exists())
 
-    def test_boost_twice(self, *_):
+    def test_boost_twice(self):
         """boost a status"""
         view = views.Boost.as_view()
         request = self.factory.post("")
@@ -171,8 +163,7 @@ class InteractionViews(TestCase):
             view(request, status.id)
         self.assertEqual(models.Boost.objects.count(), 1)
 
-    @patch("bookwyrm.activitystreams.add_status_task.delay")
-    def test_unboost(self, *_):
+    def test_unboost(self):
         """undo a boost"""
         view = views.Unboost.as_view()
         request = self.factory.post("")

--- a/bookwyrm/tests/views/test_isbn.py
+++ b/bookwyrm/tests/views/test_isbn.py
@@ -18,19 +18,14 @@ class IsbnViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Test Book",

--- a/bookwyrm/tests/views/test_notifications.py
+++ b/bookwyrm/tests/views/test_notifications.py
@@ -1,6 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
 from django.template.response import TemplateResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -16,23 +15,17 @@ class NotificationViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.another_user = models.User.objects.create_user(
-                "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
-            )
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            cls.status = models.Status.objects.create(content="hi", user=cls.local_user)
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.another_user = models.User.objects.create_user(
+            "rat", "rat@rat.rat", "ratword", local=True, localname="rat"
+        )
+        cls.status = models.Status.objects.create(content="hi", user=cls.local_user)
 
     def setUp(self):
         """individual test setup"""
@@ -148,14 +141,10 @@ class NotificationViews(TestCase):
     def test_notifications_page_list(self):
         """Adding books to lists"""
         book = models.Edition.objects.create(title="shape")
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            book_list = models.List.objects.create(user=self.local_user, name="hi")
-            item = models.ListItem.objects.create(
-                book=book, user=self.another_user, book_list=book_list, order=1
-            )
+        book_list = models.List.objects.create(user=self.local_user, name="hi")
+        item = models.ListItem.objects.create(
+            book=book, user=self.another_user, book_list=book_list, order=1
+        )
         models.Notification.notify_list_item(self.local_user, item)
         view = views.Notifications.as_view()
         request = self.factory.get("")

--- a/bookwyrm/tests/views/test_outbox.py
+++ b/bookwyrm/tests/views/test_outbox.py
@@ -1,6 +1,5 @@
 """sending out activities"""
 
-from unittest.mock import patch
 import json
 
 from django.http import JsonResponse
@@ -11,26 +10,20 @@ from bookwyrm import models, views
 from bookwyrm.settings import USER_AGENT
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class OutboxView(TestCase):
     """sends out activities"""
 
     @classmethod
     def setUpTestData(cls):
         """we'll need some data"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -42,19 +35,19 @@ class OutboxView(TestCase):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_outbox(self, _):
+    def test_outbox(self):
         """returns user's statuses"""
         request = self.factory.get("")
         result = views.Outbox.as_view()(request, "mouse")
         self.assertIsInstance(result, JsonResponse)
 
-    def test_outbox_bad_method(self, _):
+    def test_outbox_bad_method(self):
         """can't POST to outbox"""
         request = self.factory.post("")
         result = views.Outbox.as_view()(request, "mouse")
         self.assertEqual(result.status_code, 405)
 
-    def test_outbox_unknown_user(self, _):
+    def test_outbox_unknown_user(self):
         """should 404 for unknown and remote users"""
         request = self.factory.post("")
         result = views.Outbox.as_view()(request, "beepboop")
@@ -62,22 +55,20 @@ class OutboxView(TestCase):
         result = views.Outbox.as_view()(request, "rat")
         self.assertEqual(result.status_code, 405)
 
-    def test_outbox_privacy(self, _):
+    def test_outbox_privacy(self):
         """don't show dms et cetera in outbox"""
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            models.Status.objects.create(
-                content="PRIVATE!!", user=self.local_user, privacy="direct"
-            )
-            models.Status.objects.create(
-                content="bffs ONLY", user=self.local_user, privacy="followers"
-            )
-            models.Status.objects.create(
-                content="unlisted status", user=self.local_user, privacy="unlisted"
-            )
-            models.Status.objects.create(
-                content="look at this", user=self.local_user, privacy="public"
-            )
-
+        models.Status.objects.create(
+            content="PRIVATE!!", user=self.local_user, privacy="direct"
+        )
+        models.Status.objects.create(
+            content="bffs ONLY", user=self.local_user, privacy="followers"
+        )
+        models.Status.objects.create(
+            content="unlisted status", user=self.local_user, privacy="unlisted"
+        )
+        models.Status.objects.create(
+            content="look at this", user=self.local_user, privacy="public"
+        )
         request = self.factory.get("")
         result = views.Outbox.as_view()(request, "mouse")
         self.assertIsInstance(result, JsonResponse)
@@ -85,18 +76,16 @@ class OutboxView(TestCase):
         self.assertEqual(data["type"], "OrderedCollection")
         self.assertEqual(data["totalItems"], 2)
 
-    def test_outbox_filter(self, _):
+    def test_outbox_filter(self):
         """if we only care about reviews, only get reviews"""
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            models.Review.objects.create(
-                content="look at this",
-                name="hi",
-                rating=1,
-                book=self.book,
-                user=self.local_user,
-            )
-            models.Status.objects.create(content="look at this", user=self.local_user)
-
+        models.Review.objects.create(
+            content="look at this",
+            name="hi",
+            rating=1,
+            book=self.book,
+            user=self.local_user,
+        )
+        models.Status.objects.create(content="look at this", user=self.local_user)
         request = self.factory.get("", {"type": "bleh"})
         result = views.Outbox.as_view()(request, "mouse")
         self.assertIsInstance(result, JsonResponse)
@@ -111,17 +100,15 @@ class OutboxView(TestCase):
         self.assertEqual(data["type"], "OrderedCollection")
         self.assertEqual(data["totalItems"], 1)
 
-    def test_outbox_bookwyrm_request_true(self, _):
+    def test_outbox_bookwyrm_request_true(self):
         """should differentiate between bookwyrm and outside requests"""
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            models.Review.objects.create(
-                name="hi",
-                content="look at this",
-                user=self.local_user,
-                book=self.book,
-                privacy="public",
-            )
-
+        models.Review.objects.create(
+            name="hi",
+            content="look at this",
+            user=self.local_user,
+            book=self.book,
+            privacy="public",
+        )
         request = self.factory.get("", {"page": 1}, headers={"user-agent": USER_AGENT})
         result = views.Outbox.as_view()(request, "mouse")
 
@@ -129,17 +116,15 @@ class OutboxView(TestCase):
         self.assertEqual(len(data["orderedItems"]), 1)
         self.assertEqual(data["orderedItems"][0]["type"], "Review")
 
-    def test_outbox_bookwyrm_request_false(self, _):
+    def test_outbox_bookwyrm_request_false(self):
         """should differentiate between bookwyrm and outside requests"""
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            models.Review.objects.create(
-                name="hi",
-                content="look at this",
-                user=self.local_user,
-                book=self.book,
-                privacy="public",
-            )
-
+        models.Review.objects.create(
+            name="hi",
+            content="look at this",
+            user=self.local_user,
+            book=self.book,
+            privacy="public",
+        )
         request = self.factory.get("", {"page": 1})
         result = views.Outbox.as_view()(request, "mouse")
 

--- a/bookwyrm/tests/views/test_reading.py
+++ b/bookwyrm/tests/views/test_reading.py
@@ -9,39 +9,29 @@ from django.utils import timezone
 from bookwyrm import models, views
 
 
-@patch("bookwyrm.activitystreams.add_status_task.delay")
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
 class ReadingViews(TestCase):
     """viewing and creating statuses"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@rat.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@rat.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Test Book",
@@ -53,7 +43,7 @@ class ReadingViews(TestCase):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_start_reading(self, *_):
+    def test_start_reading(self):
         """begin a book"""
         shelf = self.local_user.shelf_set.get(identifier=models.Shelf.READING)
         self.assertFalse(shelf.books.exists())
@@ -95,7 +85,7 @@ class ReadingViews(TestCase):
         # 3. Create post with book attached - this should only happen once!
         self.assertEqual(len(mock.mock_calls), 3)
 
-    def test_start_reading_with_comment(self, *_):
+    def test_start_reading_with_comment(self):
         """begin a book"""
         shelf = self.local_user.shelf_set.get(identifier=models.Shelf.READING)
         self.assertFalse(shelf.books.exists())
@@ -115,8 +105,7 @@ class ReadingViews(TestCase):
             },
         )
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.ReadingStatus.as_view()(request, "start", self.book.id)
+        views.ReadingStatus.as_view()(request, "start", self.book.id)
 
         self.assertEqual(shelf.books.get(), self.book)
 
@@ -134,15 +123,12 @@ class ReadingViews(TestCase):
         self.assertEqual(readthrough.user, self.local_user)
         self.assertEqual(readthrough.book, self.book)
 
-    @patch("bookwyrm.activitystreams.add_book_statuses_task.delay")
-    @patch("bookwyrm.activitystreams.remove_book_statuses_task.delay")
-    def test_start_reading_reshelve(self, *_):
+    def test_start_reading_reshelve(self):
         """begin a book"""
         to_read_shelf = self.local_user.shelf_set.get(identifier=models.Shelf.TO_READ)
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            models.ShelfBook.objects.create(
-                shelf=to_read_shelf, book=self.book, user=self.local_user
-            )
+        models.ShelfBook.objects.create(
+            shelf=to_read_shelf, book=self.book, user=self.local_user
+        )
         shelf = self.local_user.shelf_set.get(identifier="reading")
         self.assertEqual(to_read_shelf.books.get(), self.book)
         self.assertFalse(shelf.books.exists())
@@ -150,13 +136,12 @@ class ReadingViews(TestCase):
 
         request = self.factory.post("")
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.ReadingStatus.as_view()(request, "start", self.book.id)
+        views.ReadingStatus.as_view()(request, "start", self.book.id)
 
         self.assertFalse(to_read_shelf.books.exists())
         self.assertEqual(shelf.books.get(), self.book)
 
-    def test_finish_reading(self, *_):
+    def test_finish_reading(self):
         """begin a book"""
         shelf = self.local_user.shelf_set.get(identifier=models.Shelf.READ_FINISHED)
         self.assertFalse(shelf.books.exists())
@@ -176,9 +161,7 @@ class ReadingViews(TestCase):
             },
         )
         request.user = self.local_user
-
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.ReadingStatus.as_view()(request, "finish", self.book.id)
+        views.ReadingStatus.as_view()(request, "finish", self.book.id)
 
         self.assertEqual(shelf.books.get(), self.book)
 
@@ -193,7 +176,7 @@ class ReadingViews(TestCase):
         self.assertEqual(readthrough.user, self.local_user)
         self.assertEqual(readthrough.book, self.book)
 
-    def test_edit_readthrough(self, *_):
+    def test_edit_readthrough(self):
         """adding dates to an ongoing readthrough"""
         start = timezone.make_aware(dateutil.parser.parse("2021-01-03"))
         readthrough = models.ReadThrough.objects.create(
@@ -220,7 +203,7 @@ class ReadingViews(TestCase):
         self.assertEqual(readthrough.finish_date.day, 7)
         self.assertEqual(readthrough.book, self.book)
 
-    def test_delete_readthrough(self, *_):
+    def test_delete_readthrough(self):
         """remove a readthrough"""
         readthrough = models.ReadThrough.objects.create(
             book=self.book, user=self.local_user
@@ -237,7 +220,7 @@ class ReadingViews(TestCase):
         views.delete_readthrough(request)
         self.assertFalse(models.ReadThrough.objects.filter(id=readthrough.id).exists())
 
-    def test_create_readthrough(self, *_):
+    def test_create_readthrough(self):
         """adding new read dates"""
         request = self.factory.post(
             "",
@@ -262,7 +245,7 @@ class ReadingViews(TestCase):
         self.assertEqual(readthrough.book, self.book)
         self.assertEqual(readthrough.user, self.local_user)
 
-    def test_update_progress_comment(self, *_):
+    def test_update_progress_comment(self):
         """update progress with commentary"""
         readthrough = models.ReadThrough.objects.create(
             user=self.local_user, start_date=timezone.now(), book=self.book
@@ -283,8 +266,7 @@ class ReadingViews(TestCase):
             },
         )
         request.user = self.local_user
-        with patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"):
-            views.update_progress(request, self.book.id)
+        views.update_progress(request, self.book.id)
 
         status = models.Comment.objects.get()
         self.assertEqual(status.user, self.local_user)

--- a/bookwyrm/tests/views/test_report.py
+++ b/bookwyrm/tests/views/test_report.py
@@ -1,7 +1,5 @@
 """test for app action functionality"""
 
-from unittest.mock import patch
-
 from django.test import TestCase
 from django.test.client import RequestFactory
 
@@ -15,33 +13,24 @@ class ReportViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@local.com",
-                "rat@mouse.mouse",
-                "password",
-                local=True,
-                localname="rat",
-            )
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_status_task.delay"),
-        ):
-            cls.status = models.Status.objects.create(
-                user=cls.local_user,
-                content="Test status",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@local.com",
+            "rat@mouse.mouse",
+            "password",
+            local=True,
+            localname="rat",
+        )
+        cls.status = models.Status.objects.create(
+            user=cls.local_user,
+            content="Test status",
+        )
 
     def setUp(self):
         """individual test setup"""

--- a/bookwyrm/tests/views/test_rss_feed.py
+++ b/bookwyrm/tests/views/test_rss_feed.py
@@ -1,28 +1,19 @@
 """testing import"""
 
-from unittest.mock import patch
 from django.test import RequestFactory, TestCase
 
 from bookwyrm import models
 from bookwyrm.views import rss_feed
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
-@patch("bookwyrm.activitystreams.ActivityStream.get_activity_stream")
-@patch("bookwyrm.activitystreams.add_status_task.delay")
 class RssFeedView(TestCase):
     """rss feed behaves as expected"""
 
     @classmethod
     def setUpTestData(cls):
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "rss_user", "rss@test.rss", "password", local=True
-            )
+        cls.local_user = models.User.objects.create_user(
+            "rss_user", "rss@test.rss", "password", local=True
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -34,7 +25,7 @@ class RssFeedView(TestCase):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_rss_empty(self, *_):
+    def test_rss_empty(self):
         """load an rss feed"""
         view = rss_feed.RssFeed()
         request = self.factory.get("/user/rss_user/rss")
@@ -43,7 +34,7 @@ class RssFeedView(TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertIn(b"Status updates from rss_user", result.content)
 
-    def test_rss_comment(self, *_):
+    def test_rss_comment(self):
         """load an rss feed"""
         models.Comment.objects.create(
             content="comment test content",
@@ -57,7 +48,7 @@ class RssFeedView(TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertIn(b"Example Edition", result.content)
 
-    def test_rss_review(self, *_):
+    def test_rss_review(self):
         """load an rss feed"""
         models.Review.objects.create(
             name="Review name",
@@ -72,7 +63,7 @@ class RssFeedView(TestCase):
         result = view(request, username=self.local_user.username)
         self.assertEqual(result.status_code, 200)
 
-    def test_rss_quotation(self, *_):
+    def test_rss_quotation(self):
         """load an rss feed"""
         models.Quotation.objects.create(
             quote="a sickening sense",
@@ -88,7 +79,7 @@ class RssFeedView(TestCase):
 
         self.assertIn(b"a sickening sense", result.content)
 
-    def test_rss_comment_only(self, *_):
+    def test_rss_comment_only(self):
         """load an rss feed"""
         models.Comment.objects.create(
             content="comment test content",
@@ -102,7 +93,7 @@ class RssFeedView(TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertIn(b"Example Edition", result.content)
 
-    def test_rss_review_only(self, *_):
+    def test_rss_review_only(self):
         """load an rss feed"""
         models.Review.objects.create(
             name="Review name",
@@ -117,7 +108,7 @@ class RssFeedView(TestCase):
         result = view(request, username=self.local_user.username)
         self.assertEqual(result.status_code, 200)
 
-    def test_rss_quotation_only(self, *_):
+    def test_rss_quotation_only(self):
         """load an rss feed"""
         models.Quotation.objects.create(
             quote="a sickening sense",
@@ -135,20 +126,16 @@ class RssFeedView(TestCase):
 
     def test_rss_shelf(self, *_):
         """load the rss feed of a shelf"""
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.activitystreams.add_book_statuses_task.delay"),
-        ):
-            # make the shelf
-            shelf = models.Shelf.objects.create(
-                name="Test Shelf", identifier="test-shelf", user=self.local_user
-            )
-            # put the shelf on the book
-            models.ShelfBook.objects.create(
-                book=self.book,
-                shelf=shelf,
-                user=self.local_user,
-            )
+        # make the shelf
+        shelf = models.Shelf.objects.create(
+            name="Test Shelf", identifier="test-shelf", user=self.local_user
+        )
+        # put the shelf on the book
+        models.ShelfBook.objects.create(
+            book=self.book,
+            shelf=shelf,
+            user=self.local_user,
+        )
         view = rss_feed.RssShelfFeed()
         request = self.factory.get("/user/books/test-shelf/rss")
         request.user = self.local_user

--- a/bookwyrm/tests/views/test_search.py
+++ b/bookwyrm/tests/views/test_search.py
@@ -21,19 +21,14 @@ class Views(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
         cls.work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Test Book",
@@ -86,13 +81,15 @@ class Views(TestCase):
 
         request = self.factory.get("", {"q": "Test Book", "remote": True})
         request.user = self.local_user
-        with patch("bookwyrm.views.search.is_api_request") as is_api:
+        with (
+            patch("bookwyrm.views.search.is_api_request") as is_api,
+            patch("bookwyrm.connectors.connector_manager.search") as remote_search,
+        ):
             is_api.return_value = False
-            with patch("bookwyrm.connectors.connector_manager.search") as remote_search:
-                remote_search.return_value = [
-                    {"results": [mock_result], "connector": connector}
-                ]
-                response = view(request)
+            remote_search.return_value = [
+                {"results": [mock_result], "connector": connector}
+            ]
+            response = view(request)
 
         self.assertIsInstance(response, TemplateResponse)
         validate_html(response.render())
@@ -136,13 +133,15 @@ class Views(TestCase):
         anonymous_user = AnonymousUser
         anonymous_user.is_authenticated = False
         request.user = anonymous_user
-        with patch("bookwyrm.views.search.is_api_request") as is_api:
+        with (
+            patch("bookwyrm.views.search.is_api_request") as is_api,
+            patch("bookwyrm.connectors.connector_manager.search") as remote_search,
+        ):
             is_api.return_value = False
-            with patch("bookwyrm.connectors.connector_manager.search") as remote_search:
-                remote_search.return_value = [
-                    {"results": [mock_result], "connector": connector}
-                ]
-                response = view(request)
+            remote_search.return_value = [
+                {"results": [mock_result], "connector": connector}
+            ]
+            response = view(request)
 
         self.assertIsInstance(response, TemplateResponse)
         validate_html(response.render())
@@ -191,13 +190,7 @@ class Views(TestCase):
 
     def test_search_lists(self):
         """searches remote connectors"""
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.lists_stream.remove_list_task.delay"),
-        ):
-            booklist = models.List.objects.create(
-                user=self.local_user, name="test list"
-            )
+        booklist = models.List.objects.create(user=self.local_user, name="test list")
         view = views.Search.as_view()
         request = self.factory.get("", {"q": "test", "type": "list"})
         request.user = self.local_user

--- a/bookwyrm/tests/views/test_status.py
+++ b/bookwyrm/tests/views/test_status.py
@@ -15,33 +15,27 @@ from bookwyrm.settings import DOMAIN
 from bookwyrm.tests.validate_html import validate_html
 
 
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class StatusTransactions(TransactionTestCase):
     """Test full database transactions"""
 
     def setUp(self):
         """we need basic test data and mocks"""
         self.factory = RequestFactory()
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            self.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-            self.another_user = models.User.objects.create_user(
-                f"nutria@{DOMAIN}",
-                "nutria@nutria.com",
-                "password",
-                local=True,
-                localname="nutria",
-            )
+        self.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        self.another_user = models.User.objects.create_user(
+            f"nutria@{DOMAIN}",
+            "nutria@nutria.com",
+            "password",
+            local=True,
+            localname="nutria",
+        )
 
         work = models.Work.objects.create(title="Test Work")
         self.book = models.Edition.objects.create(
@@ -50,7 +44,7 @@ class StatusTransactions(TransactionTestCase):
             parent_work=work,
         )
 
-    def test_create_status_saves(self, *_):
+    def test_create_status_saves(self):
         """This view calls save multiple times"""
         view = views.CreateStatus.as_view()
         form = forms.CommentForm(
@@ -70,48 +64,37 @@ class StatusTransactions(TransactionTestCase):
         self.assertEqual(mock.call_count, 1)
 
 
-@patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-@patch("bookwyrm.activitystreams.populate_stream_task.delay")
-@patch("bookwyrm.lists_stream.populate_lists_task.delay")
-@patch("bookwyrm.activitystreams.remove_status_task.delay")
-@patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
 class StatusViews(TestCase):
     """viewing and creating statuses"""
 
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.com",
-                "mouseword",
-                local=True,
-                localname="mouse",
-                remote_id="https://example.com/users/mouse",
-            )
-            cls.another_user = models.User.objects.create_user(
-                f"nutria@{DOMAIN}",
-                "nutria@nutria.com",
-                "password",
-                local=True,
-                localname="nutria",
-            )
-            cls.existing_hashtag = models.Hashtag.objects.create(name="#existing")
-        with patch("bookwyrm.models.user.set_remote_server"):
-            cls.remote_user = models.User.objects.create_user(
-                "rat",
-                "rat@email.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.com",
+            "mouseword",
+            local=True,
+            localname="mouse",
+            remote_id="https://example.com/users/mouse",
+        )
+        cls.another_user = models.User.objects.create_user(
+            f"nutria@{DOMAIN}",
+            "nutria@nutria.com",
+            "password",
+            local=True,
+            localname="nutria",
+        )
+        cls.existing_hashtag = models.Hashtag.objects.create(name="#existing")
+        cls.remote_user = models.User.objects.create_user(
+            "rat",
+            "rat@email.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
         work = models.Work.objects.create(title="Test Work")
         cls.book = models.Edition.objects.create(
             title="Example Edition",
@@ -123,7 +106,7 @@ class StatusViews(TestCase):
         """individual test setup"""
         self.factory = RequestFactory()
 
-    def test_create_status_comment(self, *_):
+    def test_create_status_comment(self):
         """create a status"""
         view = views.CreateStatus.as_view()
         form = forms.CommentForm(
@@ -146,7 +129,7 @@ class StatusViews(TestCase):
         self.assertEqual(status.book, self.book)
         self.assertIsNone(status.edited_date)
 
-    def test_create_status_rating(self, *_):
+    def test_create_status_rating(self):
         """create a status"""
         view = views.CreateStatus.as_view()
         form = forms.RatingForm(
@@ -168,7 +151,7 @@ class StatusViews(TestCase):
         self.assertEqual(status.rating, 4.0)
         self.assertIsNone(status.edited_date)
 
-    def test_create_status_progress(self, *_):
+    def test_create_status_progress(self):
         """create a status that updates a readthrough"""
         start_date = timezone.make_aware(dateutil.parser.parse("2024-07-27"))
         readthrough = models.ReadThrough.objects.create(
@@ -199,7 +182,7 @@ class StatusViews(TestCase):
         self.assertEqual(1, readthrough.progress)
         self.assertEqual(start_date, readthrough.start_date)  # not overwritten
 
-    def test_create_status_wrong_user(self, *_):
+    def test_create_status_wrong_user(self):
         """You can't compose statuses for someone else"""
         view = views.CreateStatus.as_view()
         form = forms.CommentForm(
@@ -215,7 +198,7 @@ class StatusViews(TestCase):
         with self.assertRaises(PermissionDenied):
             view(request, "comment")
 
-    def test_create_status_reply(self, *_):
+    def test_create_status_reply(self):
         """create a status in reply to an existing status"""
         view = views.CreateStatus.as_view()
         user = models.User.objects.create_user(
@@ -242,7 +225,7 @@ class StatusViews(TestCase):
         self.assertEqual(status.user, user)
         self.assertEqual(models.Notification.objects.get().user, self.local_user)
 
-    def test_create_status_mentions(self, *_):
+    def test_create_status_mentions(self):
         """@mention a user in a post"""
         view = views.CreateStatus.as_view()
         user = models.User.objects.create_user(
@@ -272,7 +255,7 @@ class StatusViews(TestCase):
             status.content, f'<p>hi <a href="{user.remote_id}">@rat</a></p>'
         )
 
-    def test_create_status_reply_with_mentions(self, *_):
+    def test_create_status_reply_with_mentions(self):
         """reply to a post with an @mention'd user"""
         view = views.CreateStatus.as_view()
         user = models.User.objects.create_user(
@@ -312,7 +295,7 @@ class StatusViews(TestCase):
         self.assertFalse(self.remote_user in reply.mention_users.all())
         self.assertTrue(self.local_user in reply.mention_users.all())
 
-    def test_find_mentions_local(self, *_):
+    def test_find_mentions_local(self):
         """detect and look up @ mentions of users"""
         result = find_mentions(self.local_user, "@nutria")
         self.assertEqual(result["@nutria"], self.another_user)
@@ -332,14 +315,14 @@ class StatusViews(TestCase):
 
         self.assertEqual(find_mentions(self.local_user, "leading@nutria"), {})
 
-    def test_find_mentions_remote(self, *_):
+    def test_find_mentions_remote(self):
         """detect and look up @ mentions of users"""
         self.assertEqual(
             find_mentions(self.local_user, "@rat@example.com"),
             {"@rat@example.com": self.remote_user},
         )
 
-    def test_find_mentions_multiple(self, *_):
+    def test_find_mentions_multiple(self):
         """detect and look up @ mentions of users"""
         multiple = find_mentions(self.local_user, "@nutria and @rat@example.com")
         self.assertEqual(multiple["@nutria"], self.another_user)
@@ -347,20 +330,20 @@ class StatusViews(TestCase):
         self.assertEqual(multiple["@rat@example.com"], self.remote_user)
         self.assertIsNone(multiple.get("@rat"))
 
-    def test_find_mentions_unknown(self, *_):
+    def test_find_mentions_unknown(self):
         """detect and look up @ mentions of users"""
         multiple = find_mentions(self.local_user, "@nutria and @rdkjfgh")
         self.assertEqual(multiple["@nutria"], self.another_user)
         self.assertEqual(multiple[f"@nutria@{DOMAIN}"], self.another_user)
 
-    def test_find_mentions_blocked(self, *_):
+    def test_find_mentions_blocked(self):
         """detect and look up @ mentions of users"""
         self.another_user.blocks.add(self.local_user)
 
         result = find_mentions(self.local_user, "@nutria hello")
         self.assertEqual(result, {})
 
-    def test_find_mentions_unknown_remote(self, *_):
+    def test_find_mentions_unknown_remote(self):
         """mention a user that isn't in the database"""
         with patch("bookwyrm.views.status.handle_remote_webfinger") as rwf:
             rwf.return_value = self.another_user
@@ -373,7 +356,7 @@ class StatusViews(TestCase):
             result = find_mentions(self.local_user, "@beep@beep.com")
             self.assertEqual(result, {})
 
-    def test_create_status_hashtags(self, *_):
+    def test_create_status_hashtags(self):
         """#mention a hashtag in a post"""
         view = views.CreateStatus.as_view()
         form = forms.CommentForm(
@@ -406,7 +389,7 @@ class StatusViews(TestCase):
             + "#NewTag</a>.</p>",
         )
 
-    def test_find_or_create_hashtags(self, *_):
+    def test_find_or_create_hashtags(self):
         """detect and look up #hashtags"""
         result = find_or_create_hashtags("no hashtag to be found here")
         self.assertEqual(result, {})
@@ -438,7 +421,7 @@ class StatusViews(TestCase):
         hashtag = models.Hashtag.objects.filter(name="#ひぐま").first()
         self.assertEqual(result["#ひぐま"], hashtag)
 
-    def test_format_links_simple_url(self, *_):
+    def test_format_links_simple_url(self):
         """find and format urls into a tags"""
         url = "http://www.fish.com/"
         self.assertEqual(
@@ -449,7 +432,7 @@ class StatusViews(TestCase):
             f'(<a href="{url}">www.fish.com/</a>)',
         )
 
-    def test_format_links_paragraph_break(self, *_):
+    def test_format_links_paragraph_break(self):
         """find and format urls into a tags"""
         url = """okay
 
@@ -459,7 +442,7 @@ http://www.fish.com/"""
             'okay\n\n<a href="http://www.fish.com/">www.fish.com/</a>',
         )
 
-    def test_format_links_punctuation(self, *_):
+    def test_format_links_punctuation(self):
         """test many combinations of brackets, URLs, and punctuation"""
         url = "https://bookwyrm.social"
         html = f'<a href="{url}">bookwyrm.social</a>'
@@ -479,7 +462,7 @@ http://www.fish.com/"""
             with self.subTest(desc=desc):
                 self.assertEqual(views.status.format_links(text), output)
 
-    def test_format_links_special_chars(self, *_):
+    def test_format_links_special_chars(self):
         """find and format urls into a tags"""
         url = "https://archive.org/details/dli.granth.72113/page/n25/mode/2up"
         self.assertEqual(
@@ -507,14 +490,14 @@ http://www.fish.com/"""
             views.status.format_links(url), f'<a href="{url}">{url[8:]}</a>'
         )
 
-    def test_format_links_ignore_non_urls(self, *_):
+    def test_format_links_ignore_non_urls(self):
         """formating links should leave plain text untouced"""
         text_elision = "> “The distinction is significant.” [...]"  # bookwyrm#2993
         text_quoteparens = "some kind of gene-editing technology (?)"  # bookwyrm#3049
         self.assertEqual(views.status.format_links(text_elision), text_elision)
         self.assertEqual(views.status.format_links(text_quoteparens), text_quoteparens)
 
-    def test_format_mentions_with_at_symbol_links(self, *_):
+    def test_format_mentions_with_at_symbol_links(self):
         """A link with an @username shouldn't treat the username as a mention"""
         content = "a link to https://example.com/user/@mouse"
         mentions = views.status.find_mentions(self.local_user, content)
@@ -523,7 +506,7 @@ http://www.fish.com/"""
             "a link to https://example.com/user/@mouse",
         )
 
-    def test_format_hashtag_with_pound_symbol_links(self, *_):
+    def test_format_hashtag_with_pound_symbol_links(self):
         """A link with an @username shouldn't treat the username as a mention"""
         content = "a link to https://example.com/page#anchor"
         hashtags = views.status.find_or_create_hashtags(content)
@@ -532,7 +515,7 @@ http://www.fish.com/"""
             "a link to https://example.com/page#anchor",
         )
 
-    def test_to_markdown(self, *_):
+    def test_to_markdown(self):
         """this is mostly handled in other places, but nonetheless"""
         text = "_hi_ and http://fish.com is <marquee>rad</marquee>"
         result = views.status.to_markdown(text)
@@ -541,7 +524,7 @@ http://www.fish.com/"""
             '<p><em>hi</em> and <a href="http://fish.com">fish.com</a> is rad</p>',
         )
 
-    def test_to_markdown_detect_url(self, *_):
+    def test_to_markdown_detect_url(self):
         """this is mostly handled in other places, but nonetheless"""
         text = "http://fish.com/@hello#okay"
         result = views.status.to_markdown(text)
@@ -550,17 +533,18 @@ http://www.fish.com/"""
             '<p><a href="http://fish.com/@hello#okay">fish.com/@hello#okay</a></p>',
         )
 
-    def test_to_markdown_link(self, *_):
+    def test_to_markdown_link(self):
         """this is mostly handled in other places, but nonetheless"""
         text = "[hi](http://fish.com) is <marquee>rad</marquee>"
         result = views.status.to_markdown(text)
         self.assertEqual(result, '<p><a href="http://fish.com">hi</a> is rad</p>')
 
-    def test_delete_status(self, mock, *_):
+    # TODO: use `with patch(...)` instead of decorator
+    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
+    def test_delete_status(self, mock):
         """marks a status as deleted"""
         view = views.DeleteStatus.as_view()
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            status = models.Status.objects.create(user=self.local_user, content="hi")
+        status = models.Status.objects.create(user=self.local_user, content="hi")
         self.assertFalse(status.deleted)
         request = self.factory.post("")
         request.user = self.local_user
@@ -574,11 +558,10 @@ http://www.fish.com/"""
         status.refresh_from_db()
         self.assertTrue(status.deleted)
 
-    def test_delete_status_permission_denied(self, *_):
+    def test_delete_status_permission_denied(self):
         """marks a status as deleted"""
         view = views.DeleteStatus.as_view()
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            status = models.Status.objects.create(user=self.local_user, content="hi")
+        status = models.Status.objects.create(user=self.local_user, content="hi")
         self.assertFalse(status.deleted)
         request = self.factory.post("")
         request.user = self.remote_user
@@ -589,11 +572,12 @@ http://www.fish.com/"""
         status.refresh_from_db()
         self.assertFalse(status.deleted)
 
-    def test_delete_status_moderator(self, mock, *_):
+    # TODO: use `with patch(...)` instead of decorator
+    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
+    def test_delete_status_moderator(self, mock):
         """marks a status as deleted"""
         view = views.DeleteStatus.as_view()
-        with patch("bookwyrm.activitystreams.add_status_task.delay"):
-            status = models.Status.objects.create(user=self.local_user, content="hi")
+        status = models.Status.objects.create(user=self.local_user, content="hi")
         self.assertFalse(status.deleted)
         request = self.factory.post("")
         request.user = self.remote_user
@@ -608,7 +592,7 @@ http://www.fish.com/"""
         status.refresh_from_db()
         self.assertTrue(status.deleted)
 
-    def test_edit_status_get(self, *_):
+    def test_edit_status_get(self):
         """load the edit status view"""
         view = views.EditStatus.as_view()
         status = models.Comment.objects.create(
@@ -621,7 +605,7 @@ http://www.fish.com/"""
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_edit_status_get_reply(self, *_):
+    def test_edit_status_get_reply(self):
         """load the edit status view"""
         view = views.EditStatus.as_view()
         parent = models.Comment.objects.create(
@@ -637,7 +621,9 @@ http://www.fish.com/"""
         validate_html(result.render())
         self.assertEqual(result.status_code, 200)
 
-    def test_edit_status_success(self, mock, *_):
+    # TODO: use `with patch(...)` instead of decorator
+    @patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async")
+    def test_edit_status_success(self, mock):
         """update an existing status"""
         status = models.Status.objects.create(content="status", user=self.local_user)
         self.assertIsNone(status.edited_date)
@@ -662,7 +648,7 @@ http://www.fish.com/"""
         self.assertEqual(status.content, "<p>hi</p>")
         self.assertIsNotNone(status.edited_date)
 
-    def test_edit_status_permission_denied(self, *_):
+    def test_edit_status_permission_denied(self):
         """update an existing status"""
         status = models.Status.objects.create(content="status", user=self.local_user)
         view = views.CreateStatus.as_view()

--- a/bookwyrm/tests/views/test_updates.py
+++ b/bookwyrm/tests/views/test_updates.py
@@ -16,18 +16,13 @@ class UpdateViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
 
     def setUp(self):
         """individual test setup"""

--- a/bookwyrm/tests/views/test_user.py
+++ b/bookwyrm/tests/views/test_user.py
@@ -26,21 +26,16 @@ class UserViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            cls.rat = models.User.objects.create_user(
-                "rat@local.com", "rat@rat.rat", "password", local=True, localname="rat"
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        cls.rat = models.User.objects.create_user(
+            "rat@local.com", "rat@rat.rat", "password", local=True, localname="rat"
+        )
         cls.book = models.Edition.objects.create(
             title="test", parent_work=models.Work.objects.create(title="test work")
         )
@@ -48,24 +43,18 @@ class UserViews(TestCase):
             title="recently shelved",
             parent_work=models.Work.objects.create(title="recent shelved"),
         )
-        with (
-            patch("bookwyrm.models.activitypub_mixin.broadcast_task.apply_async"),
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.add_book_statuses_task.delay"),
-        ):
-            models.ShelfBook.objects.create(
-                book=cls.book,
-                user=cls.local_user,
-                shelf=cls.local_user.shelf_set.first(),
-                shelved_date=make_date(2020, 10, 21),
-            )
-
-            models.ShelfBook.objects.create(
-                book=cls.book_recently_shelved,
-                user=cls.local_user,
-                shelf=cls.local_user.shelf_set.first(),
-                shelved_date=make_date(2024, 7, 1),
-            )
+        models.ShelfBook.objects.create(
+            book=cls.book,
+            user=cls.local_user,
+            shelf=cls.local_user.shelf_set.first(),
+            shelved_date=make_date(2020, 10, 21),
+        )
+        models.ShelfBook.objects.create(
+            book=cls.book_recently_shelved,
+            user=cls.local_user,
+            shelf=cls.local_user.shelf_set.first(),
+            shelved_date=make_date(2024, 7, 1),
+        )
 
     def setUp(self):
         """individual test setup"""
@@ -106,17 +95,15 @@ class UserViews(TestCase):
 
     def test_user_page_domain(self):
         """when the user domain has dashes in it"""
-        with patch("bookwyrm.models.user.set_remote_server"):
-            models.User.objects.create_user(
-                "nutria",
-                "",
-                "nutriaword",
-                local=False,
-                remote_id="https://ex--ample.co----m/users/nutria",
-                inbox="https://ex--ample.co----m/users/nutria/inbox",
-                outbox="https://ex--ample.co----m/users/nutria/outbox",
-            )
-
+        models.User.objects.create_user(
+            "nutria",
+            "",
+            "nutriaword",
+            local=False,
+            remote_id="https://ex--ample.co----m/users/nutria",
+            inbox="https://ex--ample.co----m/users/nutria/inbox",
+            outbox="https://ex--ample.co----m/users/nutria/outbox",
+        )
         view = views.User.as_view()
         request = self.factory.get("")
         request.user = self.local_user
@@ -195,17 +182,15 @@ class UserViews(TestCase):
 
     def test_user_page_remote_anonymous(self):
         """when a anonymous user tries to get a remote user"""
-        with patch("bookwyrm.models.user.set_remote_server"):
-            models.User.objects.create_user(
-                "nutria",
-                "",
-                "nutriaword",
-                local=False,
-                remote_id="https://example.com/users/nutria",
-                inbox="https://example.com/users/nutria/inbox",
-                outbox="https://example.com/users/nutria/outbox",
-            )
-
+        models.User.objects.create_user(
+            "nutria",
+            "",
+            "nutriaword",
+            local=False,
+            remote_id="https://example.com/users/nutria",
+            inbox="https://example.com/users/nutria/inbox",
+            outbox="https://example.com/users/nutria/outbox",
+        )
         view = views.User.as_view()
         request = self.factory.get("")
         request.user = self.anonymous_user
@@ -217,9 +202,7 @@ class UserViews(TestCase):
             result, "https://example.com/users/nutria", fetch_redirect_response=False
         )
 
-    @patch("bookwyrm.suggested_users.rerank_suggestions_task.delay")
-    @patch("bookwyrm.activitystreams.populate_stream_task.delay")
-    def test_followers_page_blocked(self, *_):
+    def test_followers_page_blocked(self):
         """there are so many views, this just makes sure it LOADS"""
         view = views.Relationships.as_view()
         request = self.factory.get("")

--- a/bookwyrm/tests/views/test_wellknown.py
+++ b/bookwyrm/tests/views/test_wellknown.py
@@ -1,7 +1,6 @@
 """test for app action functionality"""
 
 import json
-from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.http import JsonResponse
@@ -17,31 +16,25 @@ class WellknownViews(TestCase):
     @classmethod
     def setUpTestData(cls):
         """we need basic test data and mocks"""
-        with (
-            patch("bookwyrm.suggested_users.rerank_suggestions_task.delay"),
-            patch("bookwyrm.activitystreams.populate_stream_task.delay"),
-            patch("bookwyrm.lists_stream.populate_lists_task.delay"),
-        ):
-            cls.local_user = models.User.objects.create_user(
-                "mouse@local.com",
-                "mouse@mouse.mouse",
-                "password",
-                local=True,
-                localname="mouse",
-            )
-            models.User.objects.create_user(
-                "rat@local.com", "rat@rat.rat", "password", local=True, localname="rat"
-            )
-        with patch("bookwyrm.models.user.set_remote_server.delay"):
-            models.User.objects.create_user(
-                "rat",
-                "rat@remote.com",
-                "ratword",
-                local=False,
-                remote_id="https://example.com/users/rat",
-                inbox="https://example.com/users/rat/inbox",
-                outbox="https://example.com/users/rat/outbox",
-            )
+        cls.local_user = models.User.objects.create_user(
+            "mouse@local.com",
+            "mouse@mouse.mouse",
+            "password",
+            local=True,
+            localname="mouse",
+        )
+        models.User.objects.create_user(
+            "rat@local.com", "rat@rat.rat", "password", local=True, localname="rat"
+        )
+        models.User.objects.create_user(
+            "rat",
+            "rat@remote.com",
+            "ratword",
+            local=False,
+            remote_id="https://example.com/users/rat",
+            inbox="https://example.com/users/rat/inbox",
+            outbox="https://example.com/users/rat/outbox",
+        )
 
     def setUp(self):
         """individual test setup"""


### PR DESCRIPTION
This builds on top of bookwyrm-social#3151 to actually remove most `@patch` decorators in the test suite, letting tests hit in-mem celery instead.

- [x] tests/activitypub
- [x] tests/activitystreams
- [x] tests/connectors
- [x] tests/importers
- [x] tests/lists_stream
- [x] tests/management
- [x] tests/models
- [x] tests/templatetags
- [x] tests/test_*.py
- [x] tests/views/*.py
- [x] tests/views/admin
- [x] tests/views/books
- [x] tests/views/imports
- [x] tests/views/inbox
- [x] tests/views/landing
- [x] tests/views/lists
- [x] tests/views/preferences
- [x] tests/views/shelf
